### PR TITLE
sync app/config.py settings with template

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,9 @@ class Settings(BaseSettings):
     git_repos: str = ""
     im_endpoint: str = ""
     im_cloud_provider: dict = {}
-
+    im_max_time: int = 36000 # 10h
+    im_sleep: int = 30
+    im_max_retries: int = 3
+    redis_port: int = 6379
 
 settings = Settings()


### PR DESCRIPTION
Local deployment failed because of missing fields in settings. There are now two sources of truth the `app/config.py` and `config.py.j2` in production ansible deploy setup.

I simply add the field into `app/config.py`, but better to just keep only one source of truth to sync dev deployment and production deployment.