### PR TITLE
New test RO-Crate, and naming improvements

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -6,8 +6,8 @@ GALAXY_PROGRAMMING_LANGUAGE = "https://galaxyproject.org/"
 BINDER_DEFAULT_SERVICE = "https://mybinder.org"
 BINDER_PROGRAMMING_LANGUAGE = "https://jupyter.org/binder/"
 
-SCIENCEMESH_DEFAULT_SERVICE = "https://qa.cernbox.cern.ch/"
-SCIENCEMESH_PROGRAMMING_LANGUAGE = "https://qa.cernbox.cern.ch/"
+SCIENCEMESH_DEFAULT_SERVICE = "https://qa.cernbox.cern.ch"
+SCIENCEMESH_PROGRAMMING_LANGUAGE = "https://qa.cernbox.cern.ch"
 
 SCIPION_DEFAULT_SERVICE = "https://scipion.i2pc.es/"
 SCIPION_PROGRAMMING_LANGUAGE = "http://scipion.i2pc.es/"

--- a/app/vres/sciencemesh.py
+++ b/app/vres/sciencemesh.py
@@ -19,7 +19,9 @@ class VREScienceMesh(VRE):
         try:
             logging.info(f"{self.__class__.__name__}: calling {self.svc_url}")
             response = requests.post(
-                f"{self.svc_url}/ocm/shares", headers=headers, json=data
+                f"{self.svc_url}/ocm/shares",
+                headers=headers,
+                json=data,
             )
             logging.info(f"{self.__class__.__name__}: returned {response.text}")
             response.raise_for_status()
@@ -46,14 +48,14 @@ class VREScienceMesh(VRE):
         # Create OCM share request JSON structure
         ocm_share_request = {
             "shareWith": receiver.get("userid"),
-            "name": self.crate.mainEntity.get("name"),
-            "description": self.crate.mainEntity.get("description"),
+            "name": self.crate.name,
+            "description": self.crate.description,
             "providerId": "n/a",
             "resourceId": "n/a",
             "owner": owner.get("userid"),
             "senderDisplayName": sender.get("name"),
             "sender": sender_userid,
-            "resourceType": "ro-crate",
+            "resourceType": "embedded",
             "shareType": "user",
             "protocol": {
                 "name": "multi",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -180,14 +180,14 @@ def ocm_share_request(sciencemesh_vre):
 
     ocm_share_request = {
         "shareWith": receiver.get("userid"),
-        "name": sciencemesh_vre.crate.mainEntity.get("name"),
-        "description": sciencemesh_vre.crate.mainEntity.get("description"),
+        "name": sciencemesh_vre.crate.name,
+        "description": sciencemesh_vre.crate.description,
         "providerId": "n/a",
         "resourceId": "n/a",
         "owner": owner.get("userid"),
         "senderDisplayName": sender.get("name"),
         "sender": sender_userid,
-        "resourceType": "ro-crate",
+        "resourceType": "embedded",
         "shareType": "user",
         "protocol": {
             "name": "multi",

--- a/test/sciencemesh/ro-crate-metadata.json
+++ b/test/sciencemesh/ro-crate-metadata.json
@@ -54,22 +54,21 @@
                 "SoftwareSourceCode",
                 "ComputationalWorkflow"
             ],
-            "name": "ScienceMesh Data Analysis Notebook",
+            "name": "CMSDimuon_py.ipynb",
             "description": "Jupyter notebook for analyzing research data in ScienceMesh environment",
             "programmingLanguage": {
                 "@id": "#sciencemesh-jupyter"
             },
-            "url": "https://raw.githubusercontent.com/rawe0/example_notebook/main/data_analysis_example.ipynb",
+            "url": "https://raw.githubusercontent.com/dpiparo/swanExamples/refs/heads/master/notebooks/CMSDimuon_py.ipynb",
             "encodingFormat": "application/x-ipynb+json"
         },
         {
             "@id": "#dataset-csv",
             "@type": "File",
-            "name": "research_data.csv",
-            "description": "Sample research dataset in CSV format",
-            "url": "https://raw.githubusercontent.com/rawe0/example_notebook/main/sample_data.csv",
+            "name": "MuRun2010B.csv",
+            "description": "Sample dataset of dimuon events from CMS Open Data, used in the Jupyter notebook for analysis exercise",
+            "url": "https://raw.githubusercontent.com/dpiparo/swanExamples/master/notebooks/MuRun2010B.csv",
             "encodingFormat": "text/csv",
-            "contentSize": "443",
             "license": {
                 "@id": "https://creativecommons.org/licenses/by/4.0/"
             }
@@ -78,7 +77,7 @@
             "@id": "#sciencemesh-jupyter",
             "@type": "ComputerLanguage",
             "identifier": {
-                "@id": "https://qa.cernbox.cern.ch/"
+                "@id": "https://qa.cernbox.cern.ch"
             },
             "name": "Jupyter Notebook",
             "url": {
@@ -89,7 +88,7 @@
             "@id": "#destination",
             "@type": "Service",
             "name": "ScienceMesh Service",
-            "url": "http://localhost:5000",
+            "url": "https://qa.cernbox.cern.ch",
             "description": "ScienceMesh federated storage and collaboration platform"
         },
         {
@@ -112,7 +111,7 @@
         {
             "@id": "#receiver",
             "@type": "Person",
-            "userid": "rasmus.oscar.welander@cernbox.cern.ch"
+            "userid": "rwelande@cernbox.cern.ch"
         }
     ]
 }

--- a/test/unit/test_sciencemesh.py
+++ b/test/unit/test_sciencemesh.py
@@ -69,7 +69,7 @@ def test_post_succeeds_without_destination_entity(sciencemesh_vre, requests_mock
     assert sciencemesh_vre.post() == json
 
 
-def test_post_sends_correct_oscm_share_request(
+def test_post_sends_correct_ocm_share_request(
     sciencemesh_vre, requests_mock, ocm_share_request
 ):
     requests_mock.post(


### PR DESCRIPTION
This PR includes:

- A New test RO-Crate that was used for the demo
- Naming improvements (`embedded` share instead of `ro-crate`)
- Improvement to the description and name of the OCM share itself.  