### PR TITLE
Updated RO-Crate metadata for Galaxy workflow.

### DIFF
--- a/test/galaxy/ro-crate-metadata.json
+++ b/test/galaxy/ro-crate-metadata.json
@@ -41,7 +41,10 @@
         "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
       },
       "encodingFormat": "application/json",
-      "contentUrl": "https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Flaitanawe%2Fismb2024%2Fgalaxy_example/versions/main/PLAIN_GALAXY/descriptor//Galaxy-Workflow-reverse_file_galaxy_workflow.ga"
+      "contentUrl": "https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Flaitanawe%2Fismb2024%2Fgalaxy_example/versions/main/PLAIN_GALAXY/descriptor//Galaxy-Workflow-reverse_file_galaxy_workflow.ga",
+      "softwareRequirements": {
+        "@id": "#destination"
+      }
     },
     {
       "@id": "inputs/example.txt",

--- a/test/galaxy/ro-crate-metadata.json
+++ b/test/galaxy/ro-crate-metadata.json
@@ -1,69 +1,74 @@
 {
-    "@context": [
-        "https://w3id.org/ro/crate/1.1/context",
-        { "runsOn": "https://w3id.org/ro/terms/test#runsOn" }
-    ],
-    "@graph": [
+  "@context": "https://w3id.org/ro/crate/1.2/context",
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": ["Dataset"],
+      "name": "Galaxy Example Workflow",
+      "description": "This is an example of a workflow using the Galaxy platform.",
+      "license": {
+        "@id": "https://spdx.org/licenses/GPL-3.0"
+      },
+      "datePublished": "2025-05-06T14:35:47+00:00",
+      "mainEntity": {
+        "@id": "workflow/galaxy_workflow.ga"
+      },
+      "hasPart": [
         {
-            "@id": "./",
-            "@type": "Dataset",
-            "name": "Galaxy Example Workflow",
-            "description": "This is an example of a workflow using the Galaxy platform.",
-            "license": "GNU General Public License v3.0",
-            "datePublished": "2025-05-06T14:35:47+00:00",
-            "mainEntity" : { "@id": "#workflow" },
-            "runsOn" : { "@id": "#destination" },
-            "hasPart": [
-                { "@id": "#workflow" },
-                { "@id": "#textfile" },
-                { "@id": "#destination" }
-            ]
+          "@id": "workflow/galaxy_workflow.ga"
         },
         {
-            "@id": "ro-crate-metadata.json",
-            "@type": "CreativeWork",
-            "about": {
-                "@id": "./"
-            },
-            "conformsTo": {
-                "@id": "https://w3id.org/ro/crate/1.1"
-            }
-        },
-        {
-            "@id": "#workflow",
-            "@type": [
-                "File",
-                "SoftwareSourceCode",
-                "ComputationalWorkflow"
-            ],
-            "name": "Example galaxy workflow",
-            "programmingLanguage": {
-                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
-            },
-            "url": "https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Flaitanawe%2Fismb2024%2Fgalaxy_example/versions/main/PLAIN_GALAXY/descriptor//Galaxy-Workflow-reverse_file_galaxy_workflow.ga"
-        },
-        {
-            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
-            "@type": "ComputerLanguage",
-            "identifier": {
-                "@id": "https://galaxyproject.org/"
-            },
-            "name": "Galaxy",
-            "url": {
-                "@id": "https://galaxyproject.org/"
-            }
-        },
-        {
-            "@id": "#textfile",
-            "@type": "File",
-            "name": "simpletext_input",
-            "url": "https://example-files.online-convert.com/document/txt/example.txt",
-            "encodingFormat": "text/txt"
-        },
-        {
-            "@id": "#destination",
-            "@type" : "Service",
-            "url": "https://usegalaxy.eu/"
+          "@id": "inputs/example.txt"
         }
-    ]
+      ]
+    },
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "about": {
+        "@id": "./"
+      },
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.2"
+      }
+    },
+    {
+      "@id": "workflow/galaxy_workflow.ga",
+      "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
+      "name": "Example Galaxy workflow",
+      "description": "Example Galaxy workflow reversing a text file.",
+      "programmingLanguage": {
+        "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+      },
+      "encodingFormat": "application/json",
+      "contentUrl": "https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Flaitanawe%2Fismb2024%2Fgalaxy_example/versions/main/PLAIN_GALAXY/descriptor//Galaxy-Workflow-reverse_file_galaxy_workflow.ga"
+    },
+    {
+      "@id": "inputs/example.txt",
+      "@type": "File",
+      "name": "simpletext_input",
+      "encodingFormat": "text/plain",
+      "contentUrl": "https://example-files.online-convert.com/document/txt/example.txt"
+    },
+    {
+      "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
+      "@type": "ComputerLanguage",
+      "name": "Galaxy",
+      "identifier": {
+        "@id": "https://galaxyproject.org/"
+      },
+      "url": {
+        "@id": "https://galaxyproject.org/"
+      }
+    },
+    {
+      "@id": "#destination",
+      "@type": "Service",
+      "name": "Galaxy Europe",
+      "description": "Galaxy workflow execution service",
+      "url": {
+        "@id": "https://usegalaxy.eu/"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Updates:
- License is resolvable URI
- Misuse of # for Data Entities; # is for files that do not exist yet like outputs
- url -> contentUrl
- Correct MIME types
- Remove runsOn does not seem to be part of RO-Crate which might break interoperability?
- Service incorrectly in hasPart; hasPart is for Data Entities; Service is contextual.