### PR TITLE
remove web service port and use uvicorn parameter

### DIFF
--- a/ansible/templates/docker-compose.yml.j2
+++ b/ansible/templates/docker-compose.yml.j2
@@ -4,9 +4,7 @@ services:
 
   web:
     build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --ssl-keyfile {{nginx.cert}}/privkey.pem --ssl-certfile {{nginx.cert}}/fullchain.pem --log-level debug --reload 
-    ports:
-      - 8004:8000
+    command: uvicorn app.main:app --host 0.0.0.0 --port {{api.port}} --ssl-keyfile {{nginx.cert}}/privkey.pem --ssl-certfile {{nginx.cert}}/fullchain.pem --log-level debug --reload 
     volumes:
       - ./app:/usr/src/app
       - ./nginx/certbot/conf:{{nginx.cert}}


### PR DESCRIPTION
Web service port is redundant, therefore was removed. The service now uses uvicorn with --port parameter with value {{api.port}}. This variable is defined in the group vars file and is being used in nginx. Previously it relied on implicit use of port 8000 by uvicorn. 