### PR TITLE
ocm generation in dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ Testing notebook stolen from our other project, which takls to our service to fi
 Again, zip the alphafind-notebook fixture from [vre-rocrate](https://github.com/EOSC-Data-Commons/vre_rocrate) (`tests/fixtures/alphafind-notebook/`) and post the file to `/requests/zip_rocrate/`
 
 ### ScienceMesh
-Testing for ScienceMesh is currently only local, in order to test it you can run the `test/sciencemesh/test_sciencemesh_class.py` server stub and then make a POST request to the Dispatcher with the provided ro-crate `test/sciencemesh/ro-crate-metadata.json` and you should see the server receiving the ro-crate as an embedded OCM (Open Cloud Mesh) share. A ScienceMesh node is being prepared to test this remotely in order to test with CERNBox.
+Dispatches an RO-Crate as an embedded OCM (Open Cloud Mesh) share to a ScienceMesh node (default: CERNBox). The `sender` and `owner` of the share are resolved from the authenticated user's EGI Check-in identity, while the `receiver` is provided in the RO-Crate OCM metadata. For local testing, run the `test/sciencemesh/sciencemesh_vre_stub.py` server stub and POST `test/sciencemesh/ro-crate-metadata.json`.
+
+1. `POST /requests/metadata_rocrate`. Use the ScienceMesh fixture from [vre-rocrate](https://github.com/EOSC-Data-Commons/vre_rocrate) (`tests/fixtures/sciencemesh/ro-crate-metadata.json`) as payload. Only the `#receiver` needs to be modified in the RO-Crate
+2. `GET /requests/REQUEST-UUID` to retrieve the target URL to access ScienceMesh. The UUID is returned by the POST request above
 
 ---
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -4,7 +4,7 @@ GALAXY_PUBLIC_DEFAULT = False
 
 BINDER_DEFAULT_SERVICE = "https://mybinder.org"
 
-SCIENCEMESH_DEFAULT_SERVICE = "https://qa.cernbox.cern.ch"
+SCIENCEMESH_DEFAULT_SERVICE = "https://eosc.cernbox.cern.ch"
 
 SCIPION_DEFAULT_SERVICE = "https://scipion.i2pc.es/"
 

--- a/app/services/token_utils.py
+++ b/app/services/token_utils.py
@@ -1,0 +1,66 @@
+"""Utilities for extracting user identity from EGI Check-in access tokens.
+
+The access tokens issued by EGI Check-in are opaque — they do not contain
+user claims in the JWT payload.  Instead we call the federation-backend
+userinfo endpoint with the token as a Bearer.
+"""
+
+from dataclasses import dataclass
+import logging
+
+import requests
+
+from app.config import settings
+from app.exceptions import VREAuthenticationError
+
+logger = logging.getLogger(__name__)
+
+# Federation-backend userinfo URLs keyed by the egi_checkin_env setting.
+_CHECKIN_USERINFO_URLS = {
+    "prod": "https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
+    "demo": "https://aai-demo.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
+    "dev": "https://aai-dev.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
+}
+
+
+@dataclass
+class TokenUser:
+    email: str
+    name: str | None
+
+
+def extract_user_from_token(access_token: str) -> TokenUser:
+    """Resolve the user identity behind *access_token* via the EGI Check-in
+    federation backend.
+
+    Raises :class:`VREAuthenticationError` when the call fails or the
+    response does not contain a non-empty ``email`` field.
+    """
+    userinfo_url = _CHECKIN_USERINFO_URLS.get(
+        settings.egi_checkin_env,
+        _CHECKIN_USERINFO_URLS["dev"],
+    )
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        response = requests.get(userinfo_url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as e:
+        logger.error("Failed to fetch userinfo from EGI Check-in: %s", e)
+        raise VREAuthenticationError(
+            "Failed to fetch user identity from EGI Check-in"
+        ) from e
+
+    email = data.get("sub")
+    if not email:
+        logger.error("EGI Check-in userinfo response missing 'email' field")
+        raise VREAuthenticationError(
+            "Missing 'email' in user identity from EGI Check-in"
+        )
+
+    name = data.get("preferred_username")
+
+    logger.debug("Extracted user from token: email=%s, name=%s", email, name)
+    return TokenUser(email=email, name=name)

--- a/app/vres/sciencemesh.py
+++ b/app/vres/sciencemesh.py
@@ -6,6 +6,7 @@ from vre_rocrate import SCIENCEMESH_PROGRAMMING_LANGUAGE
 from app.constants import SCIENCEMESH_DEFAULT_SERVICE
 from app.config import settings
 from app.exceptions import MissingOCMParameters, ScienceMeshAPIError
+from app.services.token_utils import extract_user_from_token
 
 logger = logging.getLogger(__name__)
 
@@ -37,16 +38,19 @@ class VREScienceMesh(VRE):
         ocm = pkg.ocm_data
         if ocm is None:
             raise MissingOCMParameters(
-                "Missing OCM data (receiver, owner, sender) to dispatch via OCM to a ScienceMesh VRE"
+                "Missing OCM data to dispatch via OCM to a ScienceMesh VRE"
             )
         receiver = ocm.receiver_userid
-        owner = ocm.owner_userid
-        sender_userid = ocm.sender_userid
-        sender_name = ocm.sender_name
-        if not receiver or not owner or not sender_userid:
+        if not receiver:
             raise MissingOCMParameters(
-                "Missing required parameters (receiver, owner, sender) to dispatch via OCM to a ScienceMesh VRE"
+                "Missing required parameter 'receiver' to dispatch via OCM to a ScienceMesh VRE"
             )
+
+        # Extract sender/owner from access token (EGI Check-in federation backend)
+        token_user = extract_user_from_token(self.token)
+        sender_userid = token_user.email
+        sender_name = token_user.name or token_user.email
+
         resid = ocm.resource_id
         if resid is None:
             # TODO the resource ID should be derived from the crate itself and be invariant to multiple shares
@@ -58,7 +62,7 @@ class VREScienceMesh(VRE):
             "description": ocm.root_description or "",
             "providerId": str(uuid.uuid4()),  # must be unique for each share
             "resourceId": resid,
-            "owner": owner,
+            "owner": sender_userid,
             "senderDisplayName": sender_name,
             "sender": self._generate_ocm_address(sender_userid),
             "resourceType": "ro-crate",

--- a/app/vres/sciencemesh.py
+++ b/app/vres/sciencemesh.py
@@ -6,7 +6,7 @@ from vre_rocrate import SCIENCEMESH_PROGRAMMING_LANGUAGE
 from app.constants import SCIENCEMESH_DEFAULT_SERVICE
 from app.config import settings
 from app.exceptions import MissingOCMParameters, ScienceMeshAPIError
-from app.services.token_utils import extract_user_from_token
+from .utils.token_utils import extract_user_from_token
 
 logger = logging.getLogger(__name__)
 

--- a/app/vres/utils/token_utils.py
+++ b/app/vres/utils/token_utils.py
@@ -36,10 +36,7 @@ def extract_user_from_token(access_token: str) -> TokenUser:
     Raises :class:`VREAuthenticationError` when the call fails or the
     response does not contain a non-empty ``sub`` field.
     """
-    userinfo_url = _CHECKIN_USERINFO_URLS.get(
-        settings.egi_checkin_env,
-        _CHECKIN_USERINFO_URLS["dev"],
-    )
+    userinfo_url = _CHECKIN_USERINFO_URLS.get(settings.egi_checkin_env)
 
     headers = {"Authorization": f"Bearer {access_token}"}
 

--- a/app/vres/utils/token_utils.py
+++ b/app/vres/utils/token_utils.py
@@ -45,7 +45,7 @@ def extract_user_from_token(access_token: str) -> TokenUser:
         response.raise_for_status()
         data = response.json()
     except requests.RequestException as e:
-        logger.error("Failed to fetch userinfo from EGI Check-in: %s", e)
+        logger.error(f"Failed to fetch userinfo from EGI Check-in: {e}")
         raise VREAuthenticationError(
             "Failed to fetch user identity from EGI Check-in"
         ) from e
@@ -58,5 +58,5 @@ def extract_user_from_token(access_token: str) -> TokenUser:
 
     name = user.get("preferred_username")
 
-    logger.debug("Extracted user from token: email=%s, name=%s", email, name)
+    logger.debug(f"Extracted user from token: email={email}, name={name}")
     return TokenUser(email=email, name=name)

--- a/app/vres/utils/token_utils.py
+++ b/app/vres/utils/token_utils.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 
 # Federation-backend userinfo URLs keyed by the egi_checkin_env setting.
 _CHECKIN_USERINFO_URLS = {
-    "prod": "https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
-    "demo": "https://aai-demo.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
-    "dev": "https://aai-dev.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo",
+    "prod": "https://aai.egi.eu/federation-backend/tenants/egi/user",
+    "demo": "https://aai-demo.egi.eu/federation-backend/tenants/egi/user",
+    "dev": "https://aai-dev.egi.eu/federation-backend/tenants/egi/user",
 }
 
 
@@ -34,7 +34,7 @@ def extract_user_from_token(access_token: str) -> TokenUser:
     federation backend.
 
     Raises :class:`VREAuthenticationError` when the call fails or the
-    response does not contain a non-empty ``email`` field.
+    response does not contain a non-empty ``sub`` field.
     """
     userinfo_url = _CHECKIN_USERINFO_URLS.get(
         settings.egi_checkin_env,
@@ -53,14 +53,13 @@ def extract_user_from_token(access_token: str) -> TokenUser:
             "Failed to fetch user identity from EGI Check-in"
         ) from e
 
-    email = data.get("sub")
+    user = data.get("user", {})
+    email = user.get("sub")
     if not email:
-        logger.error("EGI Check-in userinfo response missing 'email' field")
-        raise VREAuthenticationError(
-            "Missing 'email' in user identity from EGI Check-in"
-        )
+        logger.error("EGI Check-in userinfo response missing 'sub' field")
+        raise VREAuthenticationError("Missing 'sub' in user identity from EGI Check-in")
 
-    name = data.get("preferred_username")
+    name = user.get("preferred_username")
 
     logger.debug("Extracted user from token: email=%s, name=%s", email, name)
     return TokenUser(email=email, name=name)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -291,7 +291,7 @@ def mock_token_user():
     Patches the imported reference in sciencemesh.py because the function
     is imported directly via ``from app.services.token_utils import ...``.
     """
-    from app.services.token_utils import TokenUser
+    from app.vres.utils.token_utils import TokenUser
 
     with patch(
         "app.vres.sciencemesh.extract_user_from_token",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -227,6 +227,10 @@ def binder_vre_with_doi():
     return vre
 
 
+SCIENCEMESH_SENDER_EMAIL = "rasmus.oscar.welander@egi.eu"
+SCIENCEMESH_SENDER_NAME = "Rasmus Oscar Welander"
+
+
 @pytest.fixture
 def sciencemesh_vre():
     from vre_rocrate import OCMData
@@ -241,16 +245,13 @@ def sciencemesh_vre():
         ),
         ocm_data=OCMData(
             receiver_userid="rwelande@cernbox.cern.ch",
-            owner_userid="rasmus.oscar.welander@egi.eu",
-            sender_userid="rasmus.oscar.welander@egi.eu",
-            sender_name="Rasmus Oscar Welander",
             root_name="ScienceMesh Research Data Package",
             root_description="A research data package for sharing through ScienceMesh",
         ),
         raw_crate={"@graph": []},
     )
     vre = VREScienceMesh(
-        token="test-token",
+        token="test-access-token",
         request_id=0,
         update_state=None,
         request_package=package,
@@ -270,9 +271,9 @@ def ocm_share_request(sciencemesh_vre):
         "description": ocm.root_description or "",
         "providerId": "n/a",
         "resourceId": "n/a",
-        "owner": ocm.owner_userid,
-        "senderDisplayName": ocm.sender_name,
-        "sender": sciencemesh_vre._generate_ocm_address(ocm.sender_userid),
+        "owner": SCIENCEMESH_SENDER_EMAIL,
+        "senderDisplayName": SCIENCEMESH_SENDER_NAME,
+        "sender": SCIENCEMESH_SENDER_EMAIL + "@localhost",
         "resourceType": "ro-crate",
         "shareType": "user",
         "protocol": {
@@ -281,6 +282,25 @@ def ocm_share_request(sciencemesh_vre):
         },
     }
     return ocm_share_request
+
+
+@pytest.fixture
+def mock_token_user():
+    """Mock extract_user_from_token to return a fixed TokenUser.
+
+    Patches the imported reference in sciencemesh.py because the function
+    is imported directly via ``from app.services.token_utils import ...``.
+    """
+    from app.services.token_utils import TokenUser
+
+    with patch(
+        "app.vres.sciencemesh.extract_user_from_token",
+        return_value=TokenUser(
+            email=SCIENCEMESH_SENDER_EMAIL,
+            name=SCIENCEMESH_SENDER_NAME,
+        ),
+    ) as mock:
+        yield mock
 
 
 @pytest.fixture

--- a/test/unit/test_sciencemesh.py
+++ b/test/unit/test_sciencemesh.py
@@ -1,37 +1,30 @@
 import uuid
+from unittest.mock import patch
 import pytest
-from app.exceptions import MissingOCMParameters, ScienceMeshAPIError
+from app.exceptions import (
+    MissingOCMParameters,
+    ScienceMeshAPIError,
+    VREAuthenticationError,
+)
 
 
-def test_post_errors_with_empty_rocrate(sciencemesh_vre):
+def test_post_errors_with_empty_rocrate(sciencemesh_vre, mock_token_user):
     sciencemesh_vre.request_package.ocm_data = None
 
     with pytest.raises(MissingOCMParameters):
         sciencemesh_vre.post()
 
 
-def test_post_errors_without_receiver_entity(sciencemesh_vre):
+def test_post_errors_without_receiver_entity(sciencemesh_vre, mock_token_user):
     sciencemesh_vre.request_package.ocm_data.receiver_userid = None
 
     with pytest.raises(MissingOCMParameters):
         sciencemesh_vre.post()
 
 
-def test_post_errors_without_owner_entity(sciencemesh_vre):
-    sciencemesh_vre.request_package.ocm_data.owner_userid = None
-
-    with pytest.raises(MissingOCMParameters):
-        sciencemesh_vre.post()
-
-
-def test_post_errors_without_sender_entity(sciencemesh_vre):
-    sciencemesh_vre.request_package.ocm_data.sender_userid = None
-
-    with pytest.raises(MissingOCMParameters):
-        sciencemesh_vre.post()
-
-
-def test_post_errors_on_invalid_api_response(sciencemesh_vre, requests_mock):
+def test_post_errors_on_invalid_api_response(
+    sciencemesh_vre, requests_mock, mock_token_user
+):
     requests_mock.post(
         f"{sciencemesh_vre.svc_url}/ocm/shares",
         headers={"Content-Type": "application/json", "Accept": "application/json"},
@@ -42,7 +35,7 @@ def test_post_errors_on_invalid_api_response(sciencemesh_vre, requests_mock):
         sciencemesh_vre.post()
 
 
-def test_post_returns_svc_url(sciencemesh_vre, requests_mock):
+def test_post_returns_svc_url(sciencemesh_vre, requests_mock, mock_token_user):
     json = {"data": "value"}
 
     requests_mock.post(
@@ -55,7 +48,9 @@ def test_post_returns_svc_url(sciencemesh_vre, requests_mock):
     assert sciencemesh_vre.post() == sciencemesh_vre.svc_url
 
 
-def test_post_succeeds_without_destination_entity(sciencemesh_vre, requests_mock):
+def test_post_succeeds_without_destination_entity(
+    sciencemesh_vre, requests_mock, mock_token_user
+):
     json = {"data": "value"}
 
     requests_mock.post(
@@ -68,7 +63,7 @@ def test_post_succeeds_without_destination_entity(sciencemesh_vre, requests_mock
 
 
 def test_post_sends_correct_ocm_share_request(
-    sciencemesh_vre, requests_mock, ocm_share_request
+    sciencemesh_vre, requests_mock, ocm_share_request, mock_token_user
 ):
     requests_mock.post(
         f"{sciencemesh_vre.svc_url}/ocm/shares",
@@ -85,3 +80,44 @@ def test_post_sends_correct_ocm_share_request(
         ocm_share_request.pop(key, None)
 
     assert actual == ocm_share_request
+
+
+def test_create_ocm_share_uses_token_claims_for_owner_and_sender(
+    sciencemesh_vre, mock_token_user
+):
+    result = sciencemesh_vre.create_ocm_share_request()
+
+    assert result["owner"] == "rasmus.oscar.welander@egi.eu"
+    assert result["senderDisplayName"] == "Rasmus Oscar Welander"
+    assert result["sender"].startswith("rasmus.oscar.welander@egi.eu@")
+
+
+def test_create_ocm_share_falls_back_name_to_email(sciencemesh_vre, mock_token_user):
+    from app.services.token_utils import TokenUser
+
+    mock_token_user.return_value = TokenUser(
+        email="jdoe@example.com",
+        name=None,
+    )
+
+    result = sciencemesh_vre.create_ocm_share_request()
+
+    assert result["owner"] == "jdoe@example.com"
+    assert result["senderDisplayName"] == "jdoe@example.com"
+    assert result["sender"].startswith("jdoe@example.com@")
+
+
+def test_token_extraction_raises_on_failure(sciencemesh_vre, mock_token_user):
+    mock_token_user.side_effect = VREAuthenticationError("Token validation failed")
+
+    with pytest.raises(VREAuthenticationError):
+        sciencemesh_vre.post()
+
+
+def test_token_extraction_raises_on_missing_email(sciencemesh_vre, mock_token_user):
+    mock_token_user.side_effect = VREAuthenticationError(
+        "Missing 'email' in user identity from EGI Check-in"
+    )
+
+    with pytest.raises(VREAuthenticationError):
+        sciencemesh_vre.post()

--- a/test/unit/test_sciencemesh.py
+++ b/test/unit/test_sciencemesh.py
@@ -93,7 +93,7 @@ def test_create_ocm_share_uses_token_claims_for_owner_and_sender(
 
 
 def test_create_ocm_share_falls_back_name_to_email(sciencemesh_vre, mock_token_user):
-    from app.services.token_utils import TokenUser
+    from app.vres.utils.token_utils import TokenUser
 
     mock_token_user.return_value = TokenUser(
         email="jdoe@example.com",


### PR DESCRIPTION
This PR focuses on OCM parameters generation inside dispatcher (sender, owner, ocm address). Since the token might not include all those information, token_utils was introduced to retrieve the user info. 

In the broader context, this removes the necessity of defining the user data in ROCrate, as ROCrate should be re-playable and possibly shared publicly. Also, when Dispatcher is used as a standalone service, this information can only be retrieved from the user authentication.