### PR TITLE
Add RO-Crate-driven Kubernetes and InterLink deployment flow

### DIFF
--- a/app/services/kubernetes.py
+++ b/app/services/kubernetes.py
@@ -1,24 +1,24 @@
-import logging
-import subprocess
-import time
-from typing import Dict
-from kubernetes import client as k8s_client, config
-from kubernetes.client.rest import ApiException
-from vre_rocrate import RuntimePlatform
-import uuid
 import json
-import tempfile
+import logging
 import os
 import re
 import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from typing import Dict
 
 import requests
 import urllib3
 import yaml
+from kubernetes import client as k8s_client, config
+from kubernetes.client.rest import ApiException
+from vre_rocrate import RuntimePlatform
 
 from app.config import settings
 
-# Suppress warnings from the dev Rancher's self-signed certificate.
+# Suppress warnings from the development Rancher instance's self-signed certificate.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logging.basicConfig(level=logging.INFO)
@@ -32,16 +32,43 @@ class KubernetesDeploymentError(Exception):
 
 
 class KubernetesClient:
-    """Client for deploying services to Kubernetes clusters using Helm 3 CLI.
+    """Deploy services to Kubernetes using Helm and kubectl.
 
-    Supports two modes via ``Settings.rancher_mode``:
+    The client preserves the two modes supported by the upstream Kubernetes
+    branch:
 
-    * ``"local"`` — uses a static kubeconfig file (default path
-      ``/usr/src/app/k8s-config.yaml``).
-    * ``"dev"``   — exchanges the user's EGI Check-in token for a Rancher
-      token, fetches a kubeconfig from the Rancher API, and uses that
-      temporary kubeconfig for Helm operations.
+    * ``local``: use a static kubeconfig.
+    * ``dev``: exchange the user's EGI token for a Rancher token and download
+      a temporary kubeconfig.
+
+    It also supports the InterLink/RO-Crate flow:
+
+    * install an InterLink Virtual Kubelet chart;
+    * wait for the virtual node to become Ready;
+    * apply a manifest to that virtual node;
+    * uninstall a Helm release.
+
+    ``run_service`` accepts both the upstream ``RuntimePlatform`` call and the
+    dictionary-based RO-Crate call, keeping compatibility with both flows.
     """
+
+    EGI_CHECKIN_TOKEN_URL = (
+        "https://aai-dev.egi.eu/auth/realms/egi/protocol/openid-connect/token"
+    )
+    INTERLINK_CHART_VERSION = "0.6.2-pre3"
+
+    INTERLINK_TOLERATIONS = [
+        {
+            "key": "virtual-node.interlink/no-schedule",
+            "operator": "Exists",
+            "effect": "NoSchedule",
+        },
+        {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+        },
+    ]
 
     def __init__(
         self,
@@ -51,7 +78,7 @@ class KubernetesClient:
     ):
         self._temp_kubeconfig: str | None = None
 
-        if settings.rancher_mode == "dev" and user_token:
+        if getattr(settings, "rancher_mode", "local") == "dev" and user_token:
             self._temp_kubeconfig = self._generate_rancher_kubeconfig(user_token)
             self.kubeconfig = self._temp_kubeconfig
             self.context = self._read_kubeconfig_context(self.kubeconfig)
@@ -65,27 +92,25 @@ class KubernetesClient:
         self._setup_helm_client()
 
     # ------------------------------------------------------------------
-    # Dev Rancher helpers
+    # Rancher helpers retained from upstream/kubernetes
     # ------------------------------------------------------------------
 
     @staticmethod
     def _read_kubeconfig_context(kubeconfig_path: str) -> str:
         """Read the first context name from a kubeconfig file."""
-        with open(kubeconfig_path) as f:
-            cfg = yaml.safe_load(f)
-        contexts = cfg.get("contexts", [])
+        with open(kubeconfig_path, encoding="utf-8") as kubeconfig_file:
+            kubeconfig_data = yaml.safe_load(kubeconfig_file)
+
+        contexts = kubeconfig_data.get("contexts", [])
         if contexts:
             return contexts[0]["name"]
+
         raise KubernetesDeploymentError(
             "No context found in Rancher-generated kubeconfig"
         )
 
     def _generate_rancher_kubeconfig(self, user_token: str) -> str:
-        """Exchange the EGI token for a Rancher token and download a kubeconfig.
-
-        Returns the path to a temporary kubeconfig file that MUST be cleaned
-        up by the caller (or left for the OS to reclaim).
-        """
+        """Exchange the EGI token and download a temporary Rancher kubeconfig."""
         logger.info("Rancher dev mode: exchanging EGI token for Rancher token")
         exchanged = self._exchange_token(user_token)
         rancher_token = exchanged["access_token"]
@@ -95,145 +120,150 @@ class KubernetesClient:
         kubeconfig_yaml = self._fetch_rancher_kubeconfig(rancher_token)
         logger.info("Rancher dev mode: kubeconfig fetched successfully")
 
-        tf = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False, prefix="rancher-kubeconfig-"
+        temp_file = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".yaml",
+            delete=False,
+            prefix="rancher-kubeconfig-",
+            encoding="utf-8",
         )
-        tf.write(kubeconfig_yaml)
-        tf.close()
-        logger.info(f"Rancher dev mode: kubeconfig written to {tf.name}")
-        return tf.name
+        temp_file.write(kubeconfig_yaml)
+        temp_file.close()
+        logger.info("Rancher dev mode: kubeconfig written to %s", temp_file.name)
+        return temp_file.name
 
     def _exchange_token(self, user_token: str) -> dict:
-        """Perform OAuth2 token exchange at the EGI Check-in token endpoint."""
-        token_url = settings.rancher_dev_token_exchange_url
-        client_id = settings.rancher_dev_client_id
-        client_secret = settings.rancher_dev_client_secret
-        audience = settings.rancher_dev_audience
-
+        """Perform OAuth2 token exchange at the EGI Check-in endpoint."""
         try:
-            resp = requests.post(
-                token_url,
-                auth=(client_id, client_secret),
+            response = requests.post(
+                settings.rancher_dev_token_exchange_url,
+                auth=(
+                    settings.rancher_dev_client_id,
+                    settings.rancher_dev_client_secret,
+                ),
                 data={
-                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "grant_type": ("urn:ietf:params:oauth:grant-type:token-exchange"),
                     "subject_token": user_token,
-                    "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                    "audience": audience,
+                    "subject_token_type": (
+                        "urn:ietf:params:oauth:token-type:access_token"
+                    ),
+                    "audience": settings.rancher_dev_audience,
                 },
                 timeout=30,
             )
-            resp.raise_for_status()
-            return resp.json()
-        except requests.RequestException as e:
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:
             logger.exception("Rancher token exchange failed")
             raise KubernetesDeploymentError(
-                f"Token exchange to Rancher dev failed: {e}"
-            )
+                f"Token exchange to Rancher dev failed: {exc}"
+            ) from exc
 
     def _fetch_rancher_kubeconfig(self, rancher_token: str) -> str:
-        """Discover first available cluster and download its kubeconfig.
-
-        Lists clusters from the Rancher API, picks the first active one,
-        and calls the ``generateKubeconfig`` action on it.
-        """
-        base = settings.rancher_dev_url.rstrip("/")
-        auth_headers = {
+        """Select an available Rancher cluster and download its kubeconfig."""
+        base_url = settings.rancher_dev_url.rstrip("/")
+        headers = {
             "Authorization": f"Bearer {rancher_token}",
             "Content-Type": "application/json",
         }
 
-        # Step 1 — list clusters and pick the first active one
         logger.info("Rancher dev mode: listing available clusters")
         try:
-            list_resp = requests.get(
-                f"{base}/v3/clusters",
-                headers=auth_headers,
+            list_response = requests.get(
+                f"{base_url}/v3/clusters",
+                headers=headers,
                 verify=False,
                 timeout=30,
             )
-            list_resp.raise_for_status()
-        except requests.RequestException as e:
-            raise KubernetesDeploymentError(f"Failed to list Rancher clusters: {e}")
+            list_response.raise_for_status()
+        except requests.RequestException as exc:
+            raise KubernetesDeploymentError(
+                f"Failed to list Rancher clusters: {exc}"
+            ) from exc
 
-        clusters = list_resp.json().get("data", [])
+        clusters = list_response.json().get("data", [])
         if not clusters:
             raise KubernetesDeploymentError(
                 "No clusters found in Rancher dev. "
                 "Import or create at least one cluster in the Rancher UI."
             )
 
-        # Prefer the first active cluster
-        cluster_id = None
-        for c in clusters:
-            if c.get("state") == "active":
-                cluster_id = c["id"]
-                cluster_name = c.get("name", cluster_id)
-                logger.info(
-                    f"Rancher dev mode: using cluster '{cluster_name}' ({cluster_id})"
-                )
-                break
+        selected_cluster = next(
+            (cluster for cluster in clusters if cluster.get("state") == "active"),
+            clusters[0],
+        )
+        cluster_id = selected_cluster["id"]
+        logger.info(
+            "Rancher dev mode: using cluster '%s' (%s)",
+            selected_cluster.get("name", cluster_id),
+            cluster_id,
+        )
 
-        if not cluster_id:
-            # Fall back to the first cluster, even if not active
-            cluster_id = clusters[0]["id"]
-            logger.warning(
-                f"Rancher dev mode: no active cluster found, "
-                f"falling back to '{clusters[0].get('name', cluster_id)}'"
-            )
-
-        # Step 2 — generate kubeconfig for the selected cluster
-        kubeconfig_url = f"{base}/v3/clusters/{cluster_id}?action=generateKubeconfig"
-        logger.info(f"Rancher dev mode: generating kubeconfig for cluster {cluster_id}")
+        kubeconfig_url = (
+            f"{base_url}/v3/clusters/{cluster_id}?action=generateKubeconfig"
+        )
         try:
-            resp = requests.post(
+            response = requests.post(
                 kubeconfig_url,
-                headers=auth_headers,
+                headers=headers,
                 verify=False,
                 timeout=30,
             )
-            resp.raise_for_status()
-            data = resp.json()
-            kubeconfig = data.get("config") or data.get("kubeconfig") or ""
-            if not kubeconfig:
-                raw_yaml = resp.text
-                try:
-                    parsed = yaml.safe_load(raw_yaml)
-                    if isinstance(parsed, dict) and "apiVersion" in parsed:
-                        return raw_yaml
-                except yaml.YAMLError:
-                    pass
-                raise KubernetesDeploymentError(
-                    "Rancher API did not return a kubeconfig"
-                )
-            return (
-                kubeconfig
-                if isinstance(kubeconfig, str)
-                else yaml.safe_dump(kubeconfig)
+            response.raise_for_status()
+            response_data = response.json()
+            kubeconfig = (
+                response_data.get("config") or response_data.get("kubeconfig") or ""
             )
-        except requests.RequestException as e:
+
+            if kubeconfig:
+                if isinstance(kubeconfig, str):
+                    return kubeconfig
+                return yaml.safe_dump(kubeconfig)
+
+            raw_yaml = response.text
+            try:
+                parsed = yaml.safe_load(raw_yaml)
+                if isinstance(parsed, dict) and "apiVersion" in parsed:
+                    return raw_yaml
+            except yaml.YAMLError:
+                pass
+
+            raise KubernetesDeploymentError("Rancher API did not return a kubeconfig")
+        except requests.RequestException as exc:
             logger.exception("Failed to fetch kubeconfig from Rancher")
             raise KubernetesDeploymentError(
-                f"Failed to fetch kubeconfig from Rancher dev: {e}"
-            )
+                f"Failed to fetch kubeconfig from Rancher dev: {exc}"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Client setup and common values
+    # ------------------------------------------------------------------
+
+    @property
+    def _command_environment(self) -> dict:
+        """Environment used by Helm and kubectl commands."""
+        return {**os.environ, "HOME": "/tmp"}
 
     def _setup_kubernetes_client(self) -> None:
         try:
             config.load_kube_config(config_file=self.kubeconfig)
-            logger.info(f"Loaded config from {self.kubeconfig}")
-        except Exception as e:
-            raise KubernetesDeploymentError(f"K8s init failed: {e}")
+            logger.info("Loaded config from %s", self.kubeconfig)
+        except Exception as exc:
+            raise KubernetesDeploymentError(f"K8s init failed: {exc}") from exc
 
     def _setup_helm_client(self) -> None:
-        """Verify that the Helm CLI is installed and can reach the cluster."""
+        """Verify that Helm is installed and can reach the cluster."""
         try:
             version_check = subprocess.run(
                 ["helm", "version", "--short"],
                 capture_output=True,
                 text=True,
                 check=True,
+                env=self._command_environment,
             )
-            logger.info(f"Helm binary found: {version_check.stdout.strip()}")
-            connection_check = subprocess.run(
+            logger.info("Helm binary found: %s", version_check.stdout.strip())
+
+            subprocess.run(
                 [
                     "helm",
                     "list",
@@ -247,129 +277,308 @@ class KubernetesClient:
                 capture_output=True,
                 text=True,
                 check=True,
+                env=self._command_environment,
             )
-            logger.info("Helm connection to Kubernetes cluster verified successfully")
-
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr or e.stdout
+            logger.info("Helm connection to Kubernetes cluster verified")
+        except subprocess.CalledProcessError as exc:
+            detail = exc.stderr or exc.stdout or str(exc)
             raise KubernetesDeploymentError(
-                f"Helm client setup failed. Check your kubeconfig or permissions: {error_msg}"
-            )
-        except FileNotFoundError:
+                "Helm client setup failed. "
+                f"Check the kubeconfig or permissions: {detail}"
+            ) from exc
+        except FileNotFoundError as exc:
             raise KubernetesDeploymentError(
-                "Helm binary not found in the container. Is it installed in your Dockerfile?"
-            )
+                "Helm binary not found in the container"
+            ) from exc
 
     @staticmethod
     def _sanitize_quantity(raw: str) -> str:
-        """Convert a human-readable resource quantity to Kubernetes format.
-
-        ``"4 GiB"`` → ``"4Gi"``, ``"200 GiB"`` → ``"200Gi"``.
-        """
+        """Convert a human-readable resource quantity to Kubernetes format."""
         if not raw:
             return raw
-        # Remove spaces and trailing 'B' from binary prefixes (MiB → Mi, GiB → Gi, etc.)
         sanitized = raw.replace(" ", "")
-        sanitized = re.sub(r"(\d)([KMGTPE]i)B", r"\1\2", sanitized, flags=re.IGNORECASE)
-        return sanitized
+        return re.sub(
+            r"(\d)([KMGTPE]i)B",
+            r"\1\2",
+            sanitized,
+            flags=re.IGNORECASE,
+        )
 
-    def build_helm_values(self, rp: RuntimePlatform) -> Dict:
-        """Build Helm values from RuntimePlatform configuration.
-
-        Args:
-            rp: RuntimePlatform with resource requirements.
-
-        Returns:
-            Dictionary of Helm values.
-        """
-        values = {}
-
-        # Allow scheduling on control-plane nodes in small/dev clusters
-        # (supports both the legacy "master" and the newer "control-plane" taint).
-        values["tolerations"] = [
-            {
-                "key": "node-role.kubernetes.io/control-plane",
-                "operator": "Exists",
-                "effect": "NoSchedule",
+    def build_helm_values(self, runtime_platform: RuntimePlatform) -> Dict:
+        """Build values for the original RuntimePlatform-based Helm flow."""
+        values: Dict = {
+            "tolerations": [
+                {
+                    "key": "node-role.kubernetes.io/control-plane",
+                    "operator": "Exists",
+                    "effect": "NoSchedule",
+                },
+                {
+                    "key": "node-role.kubernetes.io/master",
+                    "operator": "Exists",
+                    "effect": "NoSchedule",
+                },
+            ],
+            "podSecurityContext": {
+                "runAsNonRoot": True,
+                "seccompProfile": {"type": "RuntimeDefault"},
             },
-            {
-                "key": "node-role.kubernetes.io/master",
-                "operator": "Exists",
-                "effect": "NoSchedule",
+            "securityContext": {
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"drop": ["ALL"]},
+                "runAsNonRoot": True,
+                "seccompProfile": {"type": "RuntimeDefault"},
             },
-        ]
-
-        # Standard Helm chart keys (used by charts created via 'helm create')
-        values["podSecurityContext"] = {
-            "runAsNonRoot": True,
-            "seccompProfile": {"type": "RuntimeDefault"},
-        }
-        values["securityContext"] = {
-            "allowPrivilegeEscalation": False,
-            "capabilities": {"drop": ["ALL"]},
-            "runAsNonRoot": True,
-            "seccompProfile": {"type": "RuntimeDefault"},
         }
 
-        if rp.num_cpus > 1:
-            cpu_value = str(rp.num_cpus)
+        if runtime_platform.num_cpus > 1:
+            cpu_value = str(runtime_platform.num_cpus)
             values.setdefault("resources", {}).setdefault("requests", {})[
                 "cpu"
             ] = cpu_value
             values["resources"].setdefault("limits", {})["cpu"] = cpu_value
 
-        if rp.memory:
-            mem = self._sanitize_quantity(rp.memory)
+        if runtime_platform.memory:
+            memory = self._sanitize_quantity(runtime_platform.memory)
             values.setdefault("resources", {}).setdefault("requests", {})[
                 "memory"
-            ] = mem
-            values["resources"].setdefault("limits", {})["memory"] = mem
+            ] = memory
+            values["resources"].setdefault("limits", {})["memory"] = memory
 
-        if rp.storage:
+        if runtime_platform.storage:
             values.setdefault("persistence", {})["size"] = self._sanitize_quantity(
-                rp.storage
+                runtime_platform.storage
             )
 
-        if rp.input_files:
-            values["inputFiles"] = [{"url": f.url} for f in rp.input_files]
+        if runtime_platform.input_files:
+            values["inputFiles"] = [
+                {"url": input_file.url} for input_file in runtime_platform.input_files
+            ]
 
         return values
 
-    def _find_deployment_name(self, release_name: str) -> str:
-        """Find the deployment name created by a Helm release.
+    def validate_kubernetes_config(self, dest: dict) -> None:
+        """Validate that required Kubernetes configuration is provided."""
+        if not dest.get("hasPart"):
+            raise KubernetesDeploymentError(
+                "Missing hasPart configuration with Helm chart repository"
+            )
+
+    def validate_kubernetes_uninstall_config(self, dest: dict) -> str:
+        """Validate uninstall configuration and return the Helm release name."""
+        release_name = dest.get("releaseName") or dest.get("release_name")
+        has_part = dest.get("hasPart", [])
+        if isinstance(has_part, dict):
+            has_part = [has_part]
+
+        if not release_name:
+            for chart_info in has_part:
+                release_name = chart_info.get("releaseName") or chart_info.get(
+                    "release_name"
+                )
+                if release_name:
+                    break
+
+        if not release_name:
+            raise KubernetesDeploymentError(
+                "releaseName is required to uninstall a Helm release"
+            )
+
+        return str(release_name)
+
+    def build_rocrate_values(
+        self,
+        service: dict | RuntimePlatform,
+        chart_info: dict | None = None,
+    ) -> Dict:
+        """Build Helm values from service and chart configuration.
+
+        Dispatches to a chart-specific builder based on the 'chartType' field
+        in chart_info. Defaults to generic behaviour if chartType is absent.
 
         Args:
-            release_name: Helm release name.
+            service:    The #destination node from the ROCrate.
+            chart_info: The Repo node from hasPart (optional, for backward compat).
 
         Returns:
-            Deployment name, or None if not found.
+            Dictionary of Helm values to pass to `helm upgrade --install`.
         """
-        apps_v1 = k8s_client.AppsV1Api()
-        label_selector = f"app.kubernetes.io/instance={release_name}"
-        deployments = apps_v1.list_namespaced_deployment(
-            namespace=self.namespace, label_selector=label_selector
+        chart_type = (chart_info or {}).get("chartType", "generic")
+
+        builders = {
+            "generic": self._build_generic_values,
+            "interlink": self._build_interlink_values,
+        }
+
+        if chart_type == "generic" and isinstance(service, RuntimePlatform):
+            return self.build_helm_values(service)
+
+        builder = builders.get(chart_type, self._build_generic_values)
+        return builder(service, chart_info or {})
+
+    def _build_generic_values(self, service: dict, chart_info: dict) -> Dict:
+        """Original build_helm_values logic — unchanged."""
+        values = {}
+
+        # security values for rancher
+        values["extraPodConfig"] = {
+            "securityContext": {
+                "runAsNonRoot": True,
+                "fsGroupChangePolicy": "OnRootMismatch",
+                "seccompProfile": {"type": "RuntimeDefault"},
+            }
+        }
+        values["containerSecurityContext"] = {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "runAsGroup": 1000,
+            "readOnlyRootFilesystem": True,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+        values["podSecurityContext"] = values["extraPodConfig"]["securityContext"]
+        values["securityContext"] = values["containerSecurityContext"]
+
+        # Add resource requirements
+        if service.get("processorRequirements"):
+            cpus = service["processorRequirements"]
+            if isinstance(cpus, list) and cpus:
+                cpus = cpus[0]
+            if isinstance(cpus, str) and "vCPU" in cpus:
+                if values.get("resources") is None:
+                    values["resources"] = {}
+                if values["resources"].get("requests") is None:
+                    values["resources"]["requests"] = {}
+                if values["resources"].get("limits") is None:
+                    values["resources"]["limits"] = {}
+
+                cpu_value = cpus.replace("vCPU", "").strip()
+                values["resources"]["requests"]["cpu"] = cpu_value
+                values["resources"]["limits"]["cpu"] = cpu_value
+
+        if service.get("memoryRequirements"):
+            memory = service["memoryRequirements"]
+            if values.get("resources") is None:
+                values["resources"] = {}
+            if values["resources"].get("requests") is None:
+                values["resources"]["requests"] = {}
+            if values["resources"].get("limits") is None:
+                values["resources"]["limits"] = {}
+
+            values["resources"]["requests"]["memory"] = memory
+            values["resources"]["limits"]["memory"] = memory
+
+        if service.get("storageRequirements"):
+            storage = service["storageRequirements"]
+            if values.get("persistence") is None:
+                values["persistence"] = {}
+            values["persistence"]["size"] = storage
+
+        if service.get("input"):
+            values["inputFiles"] = service["input"]
+
+        return values
+
+    def _build_interlink_values(self, service: dict, chart_info: dict) -> Dict:
+        """Build Helm values for the interLink Virtual Kubelet chart.
+
+        Maps ROCrate Repo fields to the interLink chart values schema:
+        https://github.com/interlink-hq/interlink-helm-chart
+
+        Required ROCrate fields on the Repo node:
+            nodeName         - name of the virtual node in K8s
+            interlinkAddress - HTTPS endpoint of the remote interLink API server
+
+        Optional ROCrate fields:
+            interlinkPort    - defaults to 443
+            oauthAudience
+            virtualNodeCPUs  - advertised CPU capacity of the virtual node
+            virtualNodeMemGiB
+            virtualNodePods
+        """
+        if not chart_info.get("nodeName"):
+            raise KubernetesDeploymentError(
+                "nodeName is required in Repo configuration for chartType: interlink"
+            )
+        if not chart_info.get("interlinkAddress"):
+            raise KubernetesDeploymentError(
+                "interlinkAddress is required in Repo configuration for chartType: interlink"
+            )
+
+        values = {}
+
+        # Virtual node identity
+        values["nodeName"] = chart_info["nodeName"]
+
+        # Remote interLink API server endpoint
+        values["interlink"] = {
+            "address": chart_info["interlinkAddress"],
+            "port": chart_info.get("interlinkPort", 443),
+        }
+
+        if not settings.client_id or not settings.client_secret:
+            raise KubernetesDeploymentError(
+                "Dispatcher OAuth client_id and client_secret must be configured "
+                "for chartType: interlink"
+            )
+
+        values["OAUTH"] = {
+            "enabled": True,
+            "TokenURL": self.EGI_CHECKIN_TOKEN_URL,
+            "ClientID": settings.client_id,
+            "ClientSecret": settings.client_secret,
+            "GrantType": "client_credentials",
+            "RefreshToken": "",
+            "Audience": chart_info.get("oauthAudience", ""),
+        }
+
+        values["virtualNode"] = {
+            "resources": {
+                "CPUs": chart_info.get("virtualNodeCPUs", 8),
+                "memGiB": chart_info.get("virtualNodeMemGiB", 32),
+                "pods": chart_info.get("virtualNodePods", 100),
+            }
+        }
+
+        return values
+
+    def build_chart_config(self, chart_info: dict) -> tuple:
+        if not chart_info.get("chartName"):
+            raise KubernetesDeploymentError(
+                "chartName is required in hasPart Repo configuration"
+            )
+        if not chart_info.get("url"):
+            raise KubernetesDeploymentError(
+                "url is required in hasPart Repo configuration"
+            )
+        return (
+            chart_info.get("url"),
+            chart_info.get("chartName"),
+            chart_info.get("version"),
+        )
+
+    # ------------------------------------------------------------------
+    # Deployment helpers retained from upstream/kubernetes
+    # ------------------------------------------------------------------
+
+    def _find_deployment_name(self, release_name: str) -> str | None:
+        """Find the Deployment created by a Helm release."""
+        deployments = k8s_client.AppsV1Api().list_namespaced_deployment(
+            namespace=self.namespace,
+            label_selector=f"app.kubernetes.io/instance={release_name}",
         )
         if not deployments.items:
             return None
         return deployments.items[0].metadata.name
 
     def _patch_deployment_security(self, release_name: str) -> None:
-        """Patch the deployment created by Helm to enforce PodSecurity compliance.
-
-        Uses the Python Kubernetes client (AppsV1Api) instead of ``kubectl``
-        to avoid kubectl connectivity issues through Rancher proxies.
-
-        Uses proper V1 model objects (not plain dicts) to ensure correct
-        serialization when patching the deployment.
-
-        Args:
-            release_name: Name of the Helm release (used to find the deployment).
-        """
-        pod_sc = k8s_client.V1PodSecurityContext(
+        """Patch a Helm-created Deployment for PodSecurity compliance."""
+        pod_security_context = k8s_client.V1PodSecurityContext(
             run_as_non_root=True,
             seccomp_profile=k8s_client.V1SeccompProfile(type="RuntimeDefault"),
         )
-        container_sc = k8s_client.V1SecurityContext(
+        container_security_context = k8s_client.V1SecurityContext(
             allow_privilege_escalation=False,
             capabilities=k8s_client.V1Capabilities(drop=["ALL"]),
             run_as_non_root=True,
@@ -380,66 +589,48 @@ class KubernetesClient:
             deployment_name = self._find_deployment_name(release_name)
             if not deployment_name:
                 logger.warning(
-                    f"No deployment found for release {release_name}, "
-                    f"skipping security patch"
+                    "No deployment found for release %s; " "skipping security patch",
+                    release_name,
                 )
                 return
 
             apps_v1 = k8s_client.AppsV1Api()
-            deploy = apps_v1.read_namespaced_deployment(
-                name=deployment_name, namespace=self.namespace
+            deployment = apps_v1.read_namespaced_deployment(
+                name=deployment_name,
+                namespace=self.namespace,
             )
-
-            # Apply pod-level security context
-            deploy.spec.template.spec.security_context = pod_sc
-
-            # Apply container-level security context to every container
-            for container in deploy.spec.template.spec.containers:
-                container.security_context = container_sc
+            deployment.spec.template.spec.security_context = pod_security_context
+            for container in deployment.spec.template.spec.containers:
+                container.security_context = container_security_context
 
             apps_v1.patch_namespaced_deployment(
                 name=deployment_name,
                 namespace=self.namespace,
-                body=deploy,
+                body=deployment,
             )
             logger.info(
-                f"Patched deployment {deployment_name} with security context "
-                f"for release {release_name}"
+                "Patched deployment %s with security context",
+                deployment_name,
             )
-        except ApiException as e:
+        except ApiException as exc:
             logger.warning(
-                f"Failed to patch deployment security context for "
-                f"{release_name}: {e}. The chart may already apply these "
-                f"settings or the deployment may not be ready yet."
+                "Failed to patch deployment security context for %s: %s",
+                release_name,
+                exc,
             )
 
-    def is_github_url(self, url: str) -> bool:
+    @staticmethod
+    def is_github_url(url: str) -> bool:
         return "github.com" in url.lower()
 
     def parse_github_helm_url(self, url: str) -> dict:
-        """Parse GitHub URL to extract repo, branch, and chart path.
-
-        Supports URL formats like:
-        - https://github.com/user/repo/tree/branch/path/to/chart
-        - https://github.com/user/repo/blob/branch/path/to/Chart.yaml
-
-        Args:
-            url: GitHub URL to parse
-
-        Returns:
-            Dictionary with owner, repo, branch, and chart_path keys
-
-        Raises:
-            KubernetesDeploymentError: If URL format is invalid
-        """
-        # Pattern for github.com/user/repo/tree/branch/path or blob/branch/path
+        """Extract repository, branch and chart path from a GitHub URL."""
         pattern = r"github\.com/([^/]+)/([^/]+)/(?:tree|blob)/([^/]+)/?(.*)?"
         match = re.search(pattern, url)
-
         if not match:
             raise KubernetesDeploymentError(
-                f"Invalid GitHub URL format: {url}. "
-                f"Expected format: https://github.com/<owner>/<repo>/tree/<branch>/<path>"
+                f"Invalid GitHub URL format: {url}. Expected "
+                "https://github.com/<owner>/<repo>/tree/<branch>/<path>"
             )
 
         return {
@@ -451,10 +642,7 @@ class KubernetesClient:
 
     @staticmethod
     def _clean_chart_path(path: str) -> str:
-        """Strip filename from a blob path to get the chart directory.
-
-        e.g. 'chart/Chart.yaml' → 'chart'
-        """
+        """Remove Chart.yaml from a GitHub blob path."""
         if path.endswith("/Chart.yaml"):
             return path[: -len("/Chart.yaml")]
         if path.endswith("Chart.yaml"):
@@ -462,32 +650,16 @@ class KubernetesClient:
         return path
 
     def extract_chart_from_github(self, url: str) -> str:
-        """Extract helm chart from GitHub URL.
-
-        Clones the repository at the specified branch and returns the path
-        to the chart directory.
-
-        Args:
-            url: GitHub URL pointing to the chart
-
-        Returns:
-            Path to local chart directory
-
-        Raises:
-            KubernetesDeploymentError: If clone or extraction fails
-        """
+        """Clone a GitHub repository and return its local Helm chart path."""
         parsed = self.parse_github_helm_url(url)
-
-        # Create temp directory for cloning
         temp_dir = tempfile.mkdtemp(prefix="dispatcher-helm-")
         clone_dir = os.path.join(temp_dir, "clone")
 
         try:
-            # Clone repo at specific branch (shallow clone for speed)
-            repo_url = f"https://github.com/{parsed['owner']}/{parsed['repo']}.git"
-            logger.info(f"Cloning {repo_url} branch {parsed['branch']} to {clone_dir}")
-
-            result = subprocess.run(
+            repository_url = (
+                f"https://github.com/{parsed['owner']}/{parsed['repo']}.git"
+            )
+            subprocess.run(
                 [
                     "git",
                     "clone",
@@ -496,185 +668,180 @@ class KubernetesClient:
                     "--single-branch",
                     "--branch",
                     parsed["branch"],
-                    repo_url,
+                    repository_url,
                     clone_dir,
                 ],
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            logger.info(f"Git clone successful: {result.stdout}")
 
-            # Build full path to chart directory
-            if parsed["chart_path"]:
-                chart_path = os.path.join(clone_dir, parsed["chart_path"])
-            else:
-                chart_path = clone_dir
-
-            # Verify Chart.yaml exists
-            chart_yaml = os.path.join(chart_path, "Chart.yaml")
-            if not os.path.exists(chart_yaml):
-                raise KubernetesDeploymentError(
-                    f"Chart.yaml not found at {chart_path}. "
-                    f"Please verify the chart_path in the GitHub URL is correct."
-                )
-
-            logger.info(f"Chart extracted successfully to {chart_path}")
-            return chart_path
-
-        except subprocess.CalledProcessError as e:
-            # Clean up on failure
-            shutil.rmtree(temp_dir, ignore_errors=True)
-            raise KubernetesDeploymentError(
-                f"Failed to clone GitHub repository: {e.stderr or e.stdout}"
+            chart_path = (
+                os.path.join(clone_dir, parsed["chart_path"])
+                if parsed["chart_path"]
+                else clone_dir
             )
-        except Exception as e:
-            # Clean up on failure
+            if not os.path.exists(os.path.join(chart_path, "Chart.yaml")):
+                raise KubernetesDeploymentError(f"Chart.yaml not found at {chart_path}")
+
+            return chart_path
+        except Exception:
             shutil.rmtree(temp_dir, ignore_errors=True)
-            raise KubernetesDeploymentError(f"Failed to extract chart from GitHub: {e}")
+            raise
 
     def install_release(
         self,
         repo_url: str,
         chart_name: str,
         release_name: str,
-        values: Dict = None,
+        values: Dict | None = None,
+        version: str | None = None,
+        *,
+        wait: bool = False,
+        atomic: bool = False,
+        timeout: str | None = None,
     ) -> None:
-        """Install Helm chart using helm CLI via subprocess.
-
-        Supports both Helm repository URLs and GitHub URLs.
-        For GitHub URLs, clones the repository and uses the local chart path.
-
-        Args:
-            repo_url: URL of the Helm repository or GitHub chart URL
-            chart_name: Name of the chart
-            release_name: Name for the Helm release
-            values: Dictionary of Helm values
-
-        Raises:
-            KubernetesDeploymentError: If installation fails
-        """
-        temp_files = []
-        clone_dirs = []
+        """Install a Helm chart from a repository or GitHub URL."""
+        temp_files: list[str] = []
+        cleanup_directories: list[str] = []
 
         try:
-            if self.is_github_url(repo_url):
-                logger.info(f"Detected GitHub URL, extracting chart...")
+            github_chart = self.is_github_url(repo_url)
+            if github_chart:
                 local_chart_path = self.extract_chart_from_github(repo_url)
-                clone_dirs.append(os.path.dirname(local_chart_path))
+                clone_marker = f"{os.sep}clone"
+                temp_root, marker, _ = local_chart_path.partition(clone_marker)
+                cleanup_directories.append(
+                    temp_root if marker else os.path.dirname(local_chart_path)
+                )
 
-                # Build Helm dependencies for cloned chart
-                logger.info("Building Helm dependencies for cloned chart...")
-                update_result = subprocess.run(
+                subprocess.run(
                     ["helm", "repo", "update"],
                     capture_output=True,
                     text=True,
                     timeout=120,
+                    env=self._command_environment,
                 )
-                if update_result.returncode != 0:
-                    logger.warning(f"Helm repo update warning: {update_result.stderr}")
-
-                dep_result = subprocess.run(
+                dependency_result = subprocess.run(
                     ["helm", "dependency", "build", local_chart_path],
                     capture_output=True,
                     text=True,
                     timeout=300,
+                    env=self._command_environment,
                 )
-                if dep_result.returncode != 0:
+                if dependency_result.returncode != 0:
                     logger.warning(
-                        f"Helm dependency build failed (may continue without deps): {dep_result.stderr}"
-                    )
-                else:
-                    logger.info(
-                        f"Helm dependency build successful: {dep_result.stdout}"
+                        "Helm dependency build failed: %s",
+                        dependency_result.stderr,
                     )
 
-                cmd = [
+                command = [
                     "helm",
                     "upgrade",
                     "--install",
                     release_name,
                     local_chart_path,
-                    "--namespace",
-                    self.namespace,
-                    "--kubeconfig",
-                    self.kubeconfig,
-                    "--kube-context",
-                    self.context,
                 ]
             else:
                 repo_name = chart_name.replace("/", "-").lower()
-                logger.info(f"Adding helm repo: {repo_name} {repo_url}")
                 subprocess.run(
-                    ["helm", "repo", "add", repo_name, repo_url, "--force-update"],
+                    [
+                        "helm",
+                        "repo",
+                        "add",
+                        repo_name,
+                        repo_url,
+                        "--force-update",
+                    ],
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=self._command_environment,
                 )
                 subprocess.run(
                     ["helm", "repo", "update"],
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=self._command_environment,
                 )
-
-                cmd = [
+                command = [
                     "helm",
                     "upgrade",
                     "--install",
                     release_name,
                     f"{repo_name}/{chart_name}",
+                ]
+
+            command.extend(
+                [
                     "--namespace",
                     self.namespace,
+                    "--create-namespace",
                     "--kubeconfig",
                     self.kubeconfig,
                     "--kube-context",
                     self.context,
                 ]
+            )
 
             if values:
-                tf = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-                json.dump(values, tf)
-                tf.close()
-                temp_files.append(tf.name)
-                cmd.extend(["--values", tf.name])
+                values_file = tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".json",
+                    delete=False,
+                    encoding="utf-8",
+                )
+                json.dump(values, values_file)
+                values_file.close()
+                temp_files.append(values_file.name)
+                command.extend(["--values", values_file.name])
 
-            logger.info(f"Installing release {release_name} with chart {chart_name}")
-            logger.info(f"Executing: {' '.join(cmd)}")
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            logger.info(f"Helm Success: {result.stdout}")
+            if not github_chart and chart_name == "interlink":
+                command.extend(
+                    [
+                        "--version",
+                        version or self.INTERLINK_CHART_VERSION,
+                        "--devel",
+                    ]
+                )
+            elif not github_chart and version:
+                command.extend(["--version", version])
 
-            logger.info(f"Helm release installed successfully: {release_name}")
+            if wait:
+                command.append("--wait")
+            if atomic:
+                command.append("--atomic")
+            if timeout:
+                command.extend(["--timeout", timeout])
+
+            logger.info("Executing: %s", " ".join(command))
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=True,
+                env=self._command_environment,
+            )
+            logger.info("Helm Success: %s", result.stdout)
             self.release_name = release_name
-
-        except subprocess.CalledProcessError as e:
-            detail = e.stderr or e.stdout or str(e)
-            raise KubernetesDeploymentError(f"Helm failed: {detail}")
+        except subprocess.CalledProcessError as exc:
+            detail = exc.stderr or exc.stdout or str(exc)
+            raise KubernetesDeploymentError(f"Helm failed: {detail}") from exc
         finally:
-            for f in temp_files:
-                if os.path.exists(f):
-                    os.remove(f)
-            for d in clone_dirs:
-                if os.path.exists(d):
-                    shutil.rmtree(d, ignore_errors=True)
+            for temp_file in temp_files:
+                if os.path.exists(temp_file):
+                    os.remove(temp_file)
+            for directory in cleanup_directories:
+                if os.path.exists(directory):
+                    shutil.rmtree(directory, ignore_errors=True)
 
     def get_service_url(
         self,
         service_name: str,
         timeout: int = 300,
     ) -> str:
-        """Get the service URL from Kubernetes.
-
-        Args:
-            service_name: Name of the Kubernetes service
-            timeout: Maximum time to wait for service to get external IP/hostname
-
-        Returns:
-            URL of the service
-
-        Raises:
-            KubernetesDeploymentError: If service URL cannot be obtained
-        """
+        """Get the service URL from Kubernetes."""
         try:
             logger.info(f"Retrieving URL for service {service_name}")
 
@@ -723,77 +890,213 @@ class KubernetesClient:
         except Exception as e:
             raise KubernetesDeploymentError(f"Error getting service URL: {e}")
 
-    def _log_pod_statuses(self, deployment_name: str) -> None:
-        """Log pod statuses for a deployment to help debug readiness issues."""
+    def wait_for_virtual_node(
+        self,
+        node_name: str,
+        timeout: int = 300,
+    ) -> str:
+        logger.info(f"Waiting for virtual node '{node_name}' to become Ready...")
+        v1 = k8s_client.CoreV1Api()
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                node = v1.read_node(node_name)
+                for condition in node.status.conditions:
+                    if condition.type == "Ready" and condition.status == "True":
+                        logger.info(f"Virtual node '{node_name}' is Ready")
+                        return f"Virtual node '{node_name}' is Ready"
+            except ApiException as e:
+                if e.status != 404:
+                    raise KubernetesDeploymentError(
+                        f"K8s API error while waiting for node: {e}"
+                    )
+                # 404 means the node doesn't exist yet — keep polling
+            time.sleep(10)
+
+        raise KubernetesDeploymentError(
+            f"Virtual node '{node_name}' did not become Ready within {timeout}s"
+        )
+
+    def _inject_node_selector(self, doc: dict, node_name: str) -> dict:
+        """Inject a nodeSelector and interLink tolerations into a Kubernetes resource's pod spec.
+
+        Handles Pod, Deployment, StatefulSet, DaemonSet, Job, ReplicaSet,
+        and CronJob resource kinds. Tolerations are merged (no duplicates added).
+        """
+        node_selector = {"kubernetes.io/hostname": node_name}
+        kind = doc.get("kind", "")
+
+        if kind == "Pod":
+            pod_spec = doc.setdefault("spec", {})
+            pod_spec.setdefault("nodeSelector", {}).update(node_selector)
+            self._merge_tolerations(pod_spec)
+
+        elif kind in ("Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"):
+            pod_spec = (
+                doc.setdefault("spec", {})
+                .setdefault("template", {})
+                .setdefault("spec", {})
+            )
+            pod_spec.setdefault("nodeSelector", {}).update(node_selector)
+            self._merge_tolerations(pod_spec)
+
+        elif kind == "CronJob":
+            pod_spec = (
+                doc.setdefault("spec", {})
+                .setdefault("jobTemplate", {})
+                .setdefault("spec", {})
+                .setdefault("template", {})
+                .setdefault("spec", {})
+            )
+            pod_spec.setdefault("nodeSelector", {}).update(node_selector)
+            self._merge_tolerations(pod_spec)
+
+        return doc
+
+    def _merge_tolerations(self, pod_spec: dict) -> None:
+        """Merge interLink tolerations into a pod spec, avoiding duplicates."""
+        existing = pod_spec.setdefault("tolerations", [])
+        existing_keys = {t.get("key") for t in existing}
+        for toleration in self.INTERLINK_TOLERATIONS:
+            if toleration["key"] not in existing_keys:
+                existing.append(toleration)
+
+    def apply_manifest(self, manifest_url: str, node_name: str = None) -> None:
+        """Fetch a Kubernetes manifest from a URL and apply it via kubectl.
+
+        If node_name is provided, injects a nodeSelector into every resource
+        in the manifest so pods are scheduled on the specified virtual node.
+        """
         try:
-            v1 = k8s_client.CoreV1Api()
-            label_selector = None
-            deploy = k8s_client.AppsV1Api().read_namespaced_deployment(
+            response = requests.get(manifest_url, timeout=30)
+            response.raise_for_status()
+            manifest_content = response.text
+        except requests.RequestException as e:
+            raise KubernetesDeploymentError(
+                f"Failed to fetch manifest from {manifest_url}: {e}"
+            )
+
+        if node_name:
+            docs = [
+                doc for doc in yaml.safe_load_all(manifest_content) if doc is not None
+            ]
+            docs = [self._inject_node_selector(doc, node_name) for doc in docs]
+            manifest_content = yaml.dump_all(docs)
+            logger.info(
+                f"Injected nodeSelector '{node_name}' into {len(docs)} manifest resource(s)"
+            )
+
+        helm_env = {**os.environ, "HOME": "/tmp"}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
+            tf.write(manifest_content)
+            manifest_file = tf.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "apply",
+                    "-f",
+                    manifest_file,
+                    "--namespace",
+                    self.namespace,
+                    "--kubeconfig",
+                    self.kubeconfig,
+                    "--context",
+                    self.context,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=helm_env,
+            )
+            logger.info(f"kubectl apply succeeded: {result.stdout.strip()}")
+        except subprocess.CalledProcessError as e:
+            raise KubernetesDeploymentError(
+                f"kubectl apply failed: {e.stderr or e.stdout}"
+            )
+        finally:
+            if os.path.exists(manifest_file):
+                os.remove(manifest_file)
+
+    def _log_pod_statuses(self, deployment_name: str) -> None:
+        """Log pod statuses for a Deployment."""
+        try:
+            deployment = k8s_client.AppsV1Api().read_namespaced_deployment(
                 name=deployment_name,
                 namespace=self.namespace,
             )
-            if deploy.spec.selector.match_labels:
-                labels = ",".join(
-                    f"{k}={v}" for k, v in deploy.spec.selector.match_labels.items()
+            label_selector = None
+            if deployment.spec.selector.match_labels:
+                label_selector = ",".join(
+                    f"{key}={value}"
+                    for key, value in deployment.spec.selector.match_labels.items()
                 )
-                label_selector = labels
 
-            pods = v1.list_namespaced_pod(
+            pods = k8s_client.CoreV1Api().list_namespaced_pod(
                 namespace=self.namespace,
                 label_selector=label_selector,
             )
             for pod in pods.items:
-                phase = pod.status.phase
-                conditions = []
-                if pod.status.conditions:
-                    for c in pod.status.conditions:
-                        if c.status != "True":
-                            conditions.append(f"{c.type}={c.status}:{c.reason}")
-                container_statuses = []
-                if pod.status.container_statuses:
-                    for cs in pod.status.container_statuses:
-                        waiting = getattr(cs.state, "waiting", None)
-                        if waiting:
-                            container_statuses.append(
-                                f"{cs.name}:Waiting({waiting.reason}:{waiting.message})"
-                            )
-                        terminated = getattr(cs.state, "terminated", None)
-                        if terminated:
-                            container_statuses.append(
-                                f"{cs.name}:Terminated({terminated.reason})"
-                            )
-                        if not cs.ready and not waiting and not terminated:
-                            container_statuses.append(f"{cs.name}:NotReady")
+                status_parts = [f"phase={pod.status.phase}"]
 
-                status_parts = [f"phase={phase}"]
+                conditions = [
+                    f"{condition.type}={condition.status}:{condition.reason}"
+                    for condition in (pod.status.conditions or [])
+                    if condition.status != "True"
+                ]
                 if conditions:
                     status_parts.append(f"conditions=[{', '.join(conditions)}]")
-                if container_statuses:
-                    status_parts.append(f"containers=[{', '.join(container_statuses)}]")
 
-                logger.info(f"Pod {pod.metadata.name}: {', '.join(status_parts)}")
-        except Exception as e:
-            logger.warning(f"Failed to fetch pod statuses: {e}")
+                containers = []
+                for container_status in pod.status.container_statuses or []:
+                    waiting = getattr(
+                        container_status.state,
+                        "waiting",
+                        None,
+                    )
+                    terminated = getattr(
+                        container_status.state,
+                        "terminated",
+                        None,
+                    )
+                    if waiting:
+                        containers.append(
+                            f"{container_status.name}:"
+                            f"Waiting({waiting.reason}:{waiting.message})"
+                        )
+                    elif terminated:
+                        containers.append(
+                            f"{container_status.name}:"
+                            f"Terminated({terminated.reason})"
+                        )
+                    elif not container_status.ready:
+                        containers.append(f"{container_status.name}:NotReady")
 
-    def _wait_for_rollout(self, release_name: str, timeout: int = 300) -> None:
-        """Wait for the deployment matching a Helm release to become ready.
+                if containers:
+                    status_parts.append(f"containers=[{', '.join(containers)}]")
 
-        Uses the Python Kubernetes client (AppsV1Api) instead of ``kubectl``
-        to avoid connectivity issues through Rancher proxies.
+                logger.info(
+                    "Pod %s: %s",
+                    pod.metadata.name,
+                    ", ".join(status_parts),
+                )
+        except Exception as exc:
+            logger.warning("Failed to fetch pod statuses: %s", exc)
 
-        Args:
-            release_name: Helm release name (used to find deployment via label).
-            timeout: Maximum seconds to wait.
-
-        Raises:
-            KubernetesDeploymentError: If rollout times out or fails.
-        """
-        poll = 10  # seconds per poll
+    def _wait_for_rollout(
+        self,
+        release_name: str,
+        timeout: int = 300,
+    ) -> None:
+        """Wait for the Deployment associated with a Helm release."""
+        poll_interval = 10
         deadline = time.time() + timeout
         deployment_name = None
 
         while time.time() < deadline:
-            remaining = int(deadline - time.time())
             try:
                 if deployment_name is None:
                     deployment_name = self._find_deployment_name(release_name)
@@ -801,20 +1104,22 @@ class KubernetesClient:
                         raise KubernetesDeploymentError(
                             f"No deployment found for release {release_name}"
                         )
-                    logger.info(
-                        f"Waiting for deployment {deployment_name} "
-                        f"to be ready (timeout remaining: {remaining}s)..."
-                    )
 
-                apps_v1 = k8s_client.AppsV1Api()
-                deploy = apps_v1.read_namespaced_deployment(
+                deployment = k8s_client.AppsV1Api().read_namespaced_deployment(
                     name=deployment_name,
                     namespace=self.namespace,
                 )
-                conditions = deploy.status.conditions or []
-                available = next((c for c in conditions if c.type == "Available"), None)
-                ready_replicas = deploy.status.ready_replicas or 0
-                replicas = deploy.status.replicas or 0
+                conditions = deployment.status.conditions or []
+                available = next(
+                    (
+                        condition
+                        for condition in conditions
+                        if condition.type == "Available"
+                    ),
+                    None,
+                )
+                ready_replicas = deployment.status.ready_replicas or 0
+                replicas = deployment.status.replicas or 0
 
                 if (
                     available
@@ -823,45 +1128,70 @@ class KubernetesClient:
                     and replicas > 0
                 ):
                     logger.info(
-                        f"Deployment {deployment_name} is ready "
-                        f"({ready_replicas}/{replicas} replicas)"
+                        "Deployment %s is ready (%s/%s replicas)",
+                        deployment_name,
+                        ready_replicas,
+                        replicas,
                     )
                     return
 
-                # Fetch pods to diagnose why they aren't ready
                 self._log_pod_statuses(deployment_name)
-
-                time.sleep(poll)
-
-            except Exception as e:
+            except Exception as exc:
                 logger.warning(
-                    f"Error checking deployment status for "
-                    f"{release_name}: {e}. Retrying in {poll}s..."
+                    "Error checking deployment status for %s: %s",
+                    release_name,
+                    exc,
                 )
-                time.sleep(poll)
+
+            time.sleep(poll_interval)
 
         raise KubernetesDeploymentError(
-            f"Deployment rollout timed out after {timeout}s for {release_name}"
+            f"Deployment rollout timed out after {timeout}s " f"for {release_name}"
         )
 
-    def run_service(self, rp: RuntimePlatform, chart_info: dict) -> Dict:
-        """Deploy service to Kubernetes cluster.
+    # ------------------------------------------------------------------
+    # Entry points
+    # ------------------------------------------------------------------
 
-        Args:
-            rp: RuntimePlatform with resource requirements and install_url (helm repo).
-            chart_info: Chart configuration dict with chartName.
+    def run_service(
+        self,
+        runtime_or_destination: RuntimePlatform | dict,
+        chart_info: dict | None = None,
+    ) -> Dict:
+        """Run either the upstream or the RO-Crate deployment flow.
 
-        Returns:
-            Dictionary with deployment results including URL.
-
-        Raises:
-            KubernetesDeploymentError: If deployment fails.
+        Existing upstream callers pass ``RuntimePlatform`` plus a chart
+        dictionary. The InterLink flow can pass a destination dictionary plus
+        an optional service dictionary.
         """
+        if isinstance(runtime_or_destination, RuntimePlatform):
+            return self._run_runtime_platform_service(
+                runtime_or_destination,
+                chart_info or {},
+            )
+
+        if isinstance(runtime_or_destination, dict):
+            return self._run_rocrate_service(
+                runtime_or_destination,
+                chart_info,
+            )
+
+        raise KubernetesDeploymentError(
+            "Unsupported Kubernetes service configuration: "
+            f"{type(runtime_or_destination).__name__}"
+        )
+
+    def _run_runtime_platform_service(
+        self,
+        runtime_platform: RuntimePlatform,
+        chart_info: dict,
+    ) -> Dict:
+        """Original upstream RuntimePlatform deployment path."""
         chart_name = None
         try:
-            if not rp.install_url:
+            if not runtime_platform.install_url:
                 raise KubernetesDeploymentError(
-                    "installUrl (helm repo URL) is required for Kubernetes deployment"
+                    "installUrl is required for Kubernetes deployment"
                 )
             if not chart_info.get("chartName"):
                 raise KubernetesDeploymentError(
@@ -869,72 +1199,216 @@ class KubernetesClient:
                 )
 
             chart_name = chart_info["chartName"]
-            unique_id = str(uuid.uuid4())[:8]
-            release_name = f"{chart_name}-{unique_id}"
-            service_name = release_name
-
-            values = self.build_helm_values(rp)
-
-            logger.info(
-                f"Deploying UNIQUE release {release_name} to namespace {self.namespace}"
-            )
+            release_name = f"{chart_name}-{str(uuid.uuid4())[:8]}"
+            values = self.build_helm_values(runtime_platform)
 
             self.install_release(
-                repo_url=rp.install_url,
+                repo_url=runtime_platform.install_url,
                 chart_name=chart_name,
                 release_name=release_name,
                 values=values,
             )
 
-            # Patch the resulting deployment to enforce PodSecurity compliance,
-            # since many Helm charts do not template securityContext values themselves.
             self._patch_deployment_security(release_name)
-
-            # Now wait for the rollout to complete — pods will be accepted
-            # now that the security context has been patched in.
             self._wait_for_rollout(release_name)
-
-            service_url = self.get_service_url(service_name)
+            service_url = self.get_service_url(release_name)
 
             return {
                 "url": service_url,
                 "releaseName": release_name,
                 "namespace": self.namespace,
-                "serviceName": service_name,
+                "serviceName": release_name,
             }
-        except Exception as e:
+        except Exception as exc:
             if chart_name:
                 self.cleanup_old_releases(chart_name)
-            raise KubernetesDeploymentError(f"Deployment failed: {e}")
+            raise KubernetesDeploymentError(f"Deployment failed: {exc}") from exc
+
+    def _run_rocrate_service(self, dest: dict, service: dict = None) -> Dict:
+        """Deploy or uninstall Helm releases requested by a Kubernetes service node.
+
+        Install requests deploy all charts listed in hasPart sequentially. If
+        an interlink chart is encountered, the dispatcher waits for its virtual
+        node to become Ready before proceeding, and automatically injects its
+        nodeName as a nodeSelector into all subsequent charts so their pods are
+        scheduled on the VK-HPC node.
+        """
+        has_part = dest.get("hasPart", [])
+        if isinstance(has_part, dict):
+            has_part = [has_part]
+        first_chart = has_part[0] if has_part else {}
+        action = str(
+            dest.get("action")
+            or dest.get("operation")
+            or first_chart.get("action")
+            or first_chart.get("operation")
+            or "install"
+        ).lower()
+
+        if action in ("uninstall", "delete", "remove"):
+            release_name = self.validate_kubernetes_uninstall_config(dest)
+            logger.info(
+                f"Uninstalling release '{release_name}' from namespace '{self.namespace}'"
+            )
+            self.uninstall_release(release_name)
+            return {
+                "type": "helm-release",
+                "action": "uninstall",
+                "status": "uninstalled",
+                "releaseName": release_name,
+                "namespace": self.namespace,
+                "url": f"helm://{self.namespace}/{release_name}",
+            }
+
+        if action != "install":
+            raise KubernetesDeploymentError(
+                f"Unsupported Kubernetes action: {action!r}. "
+                "Expected 'install' or 'uninstall'."
+            )
+
+        self.validate_kubernetes_config(dest)
+
+        last_result = None
+        vk_node_name = None  # set after an interlink chart is deployed
+
+        for chart_info in has_part:
+            chart_name = None
+            try:
+                chart_type = chart_info.get("chartType", "generic")
+
+                if chart_type == "manifest":
+                    manifest_url = chart_info.get("manifestUrl")
+                    if not manifest_url:
+                        raise KubernetesDeploymentError(
+                            "manifestUrl is required for chartType: manifest"
+                        )
+                    target_node = vk_node_name or chart_info.get("nodeName")
+                    logger.info(
+                        f"Applying manifest from '{manifest_url}'"
+                        + (f" targeting node '{target_node}'" if target_node else "")
+                    )
+                    self.apply_manifest(manifest_url, node_name=target_node)
+                    last_result = {
+                        "type": "manifest",
+                        "manifestUrl": manifest_url,
+                        "namespace": self.namespace,
+                    }
+                    logger.info(f"Manifest applied successfully: {last_result}")
+                    continue
+
+                # --- Helm path ---
+                repo_url, chart_name, chart_version = self.build_chart_config(
+                    chart_info
+                )
+
+                unique_id = str(uuid.uuid4())[:8]
+                release_name = f"{chart_name}-{unique_id}"
+
+                values = self.build_rocrate_values(service or {}, chart_info)
+
+                target_node = vk_node_name or (
+                    chart_info.get("nodeName") if chart_type != "interlink" else None
+                )
+                if target_node:
+                    values.setdefault("nodeSelector", {})
+                    values["nodeSelector"]["kubernetes.io/hostname"] = target_node
+                    logger.info(
+                        f"Injecting nodeSelector '{target_node}' into release '{release_name}'"
+                    )
+
+                logger.info(
+                    f"Deploying release '{release_name}' "
+                    f"(chartType={chart_type}, version={chart_version or 'latest'}) "
+                    f"to namespace '{self.namespace}'"
+                )
+
+                self.install_release(
+                    repo_url=repo_url,
+                    chart_name=chart_name,
+                    release_name=release_name,
+                    values=values,
+                    version=chart_version,
+                    wait=True,
+                    atomic=True,
+                    timeout="5m",
+                )
+
+                if chart_type == "interlink":
+                    vk_node_name = chart_info["nodeName"]
+                    status = self.wait_for_virtual_node(vk_node_name)
+                    last_result = {
+                        "type": "virtual-node",
+                        "nodeName": vk_node_name,
+                        "status": status,
+                        "releaseName": release_name,
+                        "namespace": self.namespace,
+                    }
+                else:
+                    service_url = self.get_service_url(release_name)
+                    last_result = {
+                        "type": "service",
+                        "url": service_url,
+                        "releaseName": release_name,
+                        "namespace": self.namespace,
+                        "serviceName": release_name,
+                    }
+
+                logger.info(
+                    f"Release '{release_name}' deployed successfully: {last_result}"
+                )
+
+            except Exception as e:
+                if chart_name:
+                    self.cleanup_old_releases(chart_name)
+                raise KubernetesDeploymentError(f"Deployment failed: {e}")
+
+        if last_result is None:
+            raise KubernetesDeploymentError("No charts found in hasPart configuration")
+
+        return last_result
 
     def uninstall_release(self, release_name: str) -> None:
-        """Uninstall Helm release using helm CLI subprocess."""
+        """Uninstall a Helm release."""
         try:
-            logger.info(f"Uninstalling Helm release {release_name}")
-            subprocess.run(
-                [
-                    "helm",
-                    "uninstall",
-                    release_name,
-                    "--namespace",
-                    self.namespace,
-                    "--wait",
-                    "--kubeconfig",
-                    self.kubeconfig,
-                    "--kube-context",
-                    self.context,
-                ],
+            command = [
+                "helm",
+                "uninstall",
+                release_name,
+                "--namespace",
+                self.namespace,
+                "--wait",
+                "--kubeconfig",
+                self.kubeconfig,
+                "--kube-context",
+                self.context,
+            ]
+            logger.info("Executing: %s", " ".join(command))
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
                 check=True,
+                env=self._command_environment,
             )
-            logger.info(f"Helm release uninstalled successfully: {release_name}")
-        except subprocess.CalledProcessError as e:
-            raise KubernetesDeploymentError(f"Failed to uninstall Helm release: {e}")
+            logger.info("Helm uninstall succeeded: %s", result.stdout)
+        except subprocess.CalledProcessError as exc:
+            detail = exc.stderr or exc.stdout or str(exc)
+            raise KubernetesDeploymentError(f"Helm uninstall failed: {detail}") from exc
 
-    def cleanup_old_releases(self, chart_name):
-        cmd = (
+    def cleanup_old_releases(self, chart_name: str) -> None:
+        """Remove releases matching the generated chart-name prefix."""
+        command = (
             f"helm list -n {self.namespace} --filter '{chart_name}-' -q "
-            f"--kubeconfig {self.kubeconfig} --kube-context {self.context} "
-            f"| xargs -r helm uninstall -n {self.namespace} "
-            f"--kubeconfig {self.kubeconfig} --kube-context {self.context}"
+            f"--kubeconfig {self.kubeconfig} "
+            f"--kube-context {self.context} "
+            "| xargs -r helm uninstall "
+            f"-n {self.namespace} "
+            f"--kubeconfig {self.kubeconfig} "
+            f"--kube-context {self.context}"
         )
-        subprocess.run(cmd, shell=True, capture_output=True)
+        subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            env=self._command_environment,
+        )

--- a/app/vres/base_vre.py
+++ b/app/vres/base_vre.py
@@ -1,12 +1,12 @@
 import sys
-from app import constants
 from app.services.im import IM
 from vre_rocrate import RuntimePlatform
-from app.services.kubernetes import KubernetesClient
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Mapping, Protocol, runtime_checkable
 from app.exceptions import VREConfigurationError
 import logging
+from app.services.kubernetes import KubernetesClient
+from app import constants
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,9 @@ class VRE(ABC):
         pass
 
     def setup_service(self) -> str:
+        k8s_dest = self._get_kubernetes_destination()
+        if k8s_dest is not None:
+            return self._deploy_kubernetes_destination(k8s_dest)
         rp = self._get_runtime_platform()
         return self._resolve_service_url(rp)
 
@@ -55,6 +58,108 @@ class VRE(ABC):
             return self.request_package.workflow.runtime_platform
         return None
 
+    def _find_destination_entity(self) -> dict | None:
+        """Resolve the deployment destination entity from the crate.
+
+        Accepts either link property, checked in order:
+          1. the root dataset's ``runsOn``;
+          2. the workflow's ``runtimePlatform`` (the raw reference is preserved
+             in ``workflow.properties`` even though the builder also exposes it
+             as a ``RuntimePlatform`` object).
+        Returns the raw destination entity dict, or None.
+        """
+        if self.request_package is None:
+            return None
+        ref = None
+        root = self.request_package.get_entity("./")
+        if isinstance(root, dict):
+            ref = root.get("runsOn")
+        if ref is None:
+            ref = self.request_package.workflow.properties.get("runtimePlatform")
+        entity_id = ref.get("@id") if isinstance(ref, dict) else ref
+        if not isinstance(entity_id, str) or not entity_id:
+            return None
+        entity = self.request_package.get_entity(entity_id)
+        return entity if isinstance(entity, dict) else None
+
+    def _is_kubernetes_rocrate_destination(self, dest: dict) -> bool:
+        """Whether *dest* is an InterLink/RO-Crate Kubernetes destination.
+
+        True for a Service whose ``serviceType`` is ``Kubernetes`` or any
+        destination that lists Helm/manifest Repos (``chartType``) in
+        ``hasPart``. A plain ``RuntimePlatform`` (name/installUrl/chartName with
+        no ``hasPart``) is False, so it takes the generic object path instead.
+        """
+        if dest.get("serviceType") == "Kubernetes":
+            return True
+        parts = dest.get("hasPart", [])
+        if isinstance(parts, dict):
+            parts = [parts]
+        for part in parts:
+            if isinstance(part, dict) and "@id" in part:
+                part = self.request_package.get_entity(part["@id"]) or {}
+            if isinstance(part, dict) and part.get("chartType"):
+                return True
+        return False
+
+    def _get_kubernetes_destination(self) -> dict | None:
+        """Return the fully-resolved InterLink Kubernetes destination, or None.
+
+        Discovers the destination via ``runsOn`` or ``runtimePlatform`` and,
+        when it is InterLink-shaped, returns it with ``hasPart`` ``@id``
+        references expanded to the actual Repo entities. Returns None for
+        non-Kubernetes or generic ``RuntimePlatform`` destinations so the
+        standard flow runs.
+        """
+        dest = self._find_destination_entity()
+        if dest is None or not self._is_kubernetes_rocrate_destination(dest):
+            return None
+        return self._expand_has_part(dest)
+
+    def _expand_has_part(self, dest: dict) -> dict:
+        """Return a copy of *dest* with ``hasPart`` @id references resolved.
+
+        RO-Crate lists ``hasPart`` as reference objects (``{"@id": "#x"}``); the
+        KubernetesClient's RO-Crate flow expects the concrete Repo entities, so
+        resolve each one against the graph here.
+        """
+        resolved = dict(dest)
+        parts = dest.get("hasPart", [])
+        if isinstance(parts, dict):
+            parts = [parts]
+        expanded: list = []
+        for part in parts:
+            if isinstance(part, dict) and "@id" in part:
+                entity = self.request_package.get_entity(part["@id"])
+                expanded.append(entity if isinstance(entity, dict) else part)
+            else:
+                expanded.append(part)
+        resolved["hasPart"] = expanded
+        return resolved
+
+    def _deploy_kubernetes_destination(self, dest: dict) -> str:
+        """Deploy the InterLink/Helm charts described by a Kubernetes destination.
+
+        Passes the destination as a dict so ``KubernetesClient.run_service``
+        routes to the RO-Crate flow (``_run_rocrate_service``): install each
+        chart in ``hasPart``, wait for the InterLink virtual node, and apply
+        any manifests.
+        """
+        self.update_task_status(constants.KUBERNETES_SEQUENCE_STARTED)
+        try:
+            client = KubernetesClient(user_token=self.token)
+            outputs = client.run_service(dest)
+            self.update_task_status(constants.KUBERNETES_SEQUENCE_FINISHED)
+        except Exception as exc:
+            logger.error(f"Kubernetes deployment failed: {exc}")
+            raise VREConfigurationError(
+                f"Failed to deploy service to Kubernetes: {exc}"
+            ) from exc
+        if not outputs:
+            raise VREConfigurationError("Failed to deploy service to Kubernetes")
+        self.update_task_status(constants.KUBERNETES_SEQUENCE_SUCCESSFUL)
+        return outputs.get("url", self.get_default_service())
+
     def _resolve_service_url(self, dest: str | RuntimePlatform | None) -> str:
         if dest is None:
             return self.get_default_service()
@@ -63,7 +168,7 @@ class VRE(ABC):
         if isinstance(dest, str):
             return dest
 
-        # RuntimePlatform with installUrl – delegate to Infrastructure Manager or Kubernetes.
+        # RuntimePlatform with installUrl – delegate to Infrastructure Manager.
         if dest.install_url is not None:
             if dest.name == "Infrastructure Manager":
                 logger.error(f"IM dest {dest}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ requests-mock>=1.12.1
 vre-rocrate @ git+https://github.com/EOSC-Data-Commons/vre_rocrate.git@master
 kubernetes>=25.3.0
 pyhelm>=1.2.1
+PyYAML>=6.0


### PR DESCRIPTION
**Summary**

This PR extends the Kubernetes integration to support RO-Crate-driven deployments for InterLink virtual kubelets and follow-up workloads, as well as Helm release uninstallation.

This branch was also synchronized with `upstream/master`, so part of the diff reflects upstream alignment in addition to the Kubernetes / InterLink feature work.

**What is now supported**

- install an InterLink Helm chart from a RO-Crate Kubernetes destination
- wait for the virtual kubelet node to become ready
- submit a manifest-based workload to that virtual node in the same request
- uninstall a previously deployed Helm release through a Kubernetes service request
- derive OAuth client credentials for the InterLink deployment directly from Dispatcher settings instead of sending them in plain text in the RO-Crate payload

**Example RO-Crates**

1. InterLink VK deployment plus manifest scheduling

A single RO-Crate request can:
- install the InterLink Helm chart
- deploy the virtual kubelet
- wait for the VK to become ready
- apply a manifest and schedule its workload onto that VK

```json
{
    "@context": [
      "https://w3id.org/ro/crate/1.1/context"
    ],
    "@graph": [
      {
        "@id": "ro-crate-metadata.json",
        "@type": "CreativeWork",
        "about": { "@id": "./" },
        "conformsTo": { "@id": "https://w3id.org/ro/crate/1.1" }
      },
      {
        "@id": "./",
        "@type": "Dataset",
        "name": "InterLink VK Deployment",
        "description": "Deploy InterLink Virtual Kubelet via Helm and submit a manifest to it",
        "license": "Apache-2.0",
        "datePublished": "2026-03-11T00:00:00+00:00",
        "mainEntity": { "@id": "#workflow" },
        "hasPart": [
          { "@id": "#workflow" },
          { "@id": "#destination" }
        ]
      },
      {
        "@id": "#workflow",
        "@type": [
          "File",
          "SoftwareSourceCode",
          "ComputationalWorkflow"
        ],
        "name": "InterLink VK deployment workflow",
        "programmingLanguage": { "@id": "#scipion" },
        "runtimePlatform": { "@id": "#destination" }
      },
      {
        "@id": "#scipion",
        "@type": "ComputerLanguage",
        "name": "Scipion",
        "url": { "@id": "http://scipion.i2pc.es/" },
        "identifier": "http://scipion.i2pc.es/"
      },
      {
        "@id": "#destination",
        "@type": "Service",
        "serviceType": "Kubernetes",
        "name": "InterLink VK",
        "hasPart": [
          { "@id": "#interlink.chart" },
          { "@id": "#example.pod" }
        ]
      },
      {
        "@id": "#interlink.chart",
        "@type": "Repo",
        "chartType": "interlink",
        "chartName": "interlink",
        "url": "https://interlink-hq.github.io/interlink-helm-chart/",
        "version": "0.6.2-pre3",
        "nodeName": "vk-remote-dispatcher",
        "interlinkAddress": "https://edc-interlink.vm.fedcloud.eu",
        "interlinkPort": 443,
        "virtualNodeCPUs": 64,
        "virtualNodeMemGiB": 256,
        "virtualNodePods": 500,
        "oauthAudience": "users"
      },
      {
        "@id": "#example.pod",
        "@type": "Repo",
        "chartType": "manifest",
        "manifestUrl": "https://minio.131.154.98.45.myip.cloud.infn.it/public-data/pod.yaml",
        "nodeName": "vk-remote-dispatcher"
      }
    ]
  }
```

2. InterLink VK uninstall

A Kubernetes service request can uninstall a previously deployed Helm release by providing `action: "uninstall"` and the target `releaseName`.

```json
{
    "@context": ["https://w3id.org/ro/crate/1.1/context"],
    "@graph": [
      {
        "@id": "./",
        "@type": "Dataset",
        "name": "InterLink VK Uninstall",
        "description": "Uninstall InterLink Virtual Kubelet Helm release",
        "mainEntity": { "@id": "#workflow" },
        "runsOn": { "@id": "#destination" },
        "hasPart": [ { "@id": "#workflow" }, { "@id": "#destination" } ]
      },
      {
        "@id": "ro-crate-metadata.json",
        "@type": "CreativeWork",
        "about": { "@id": "./" },
        "conformsTo": { "@id": "https://w3id.org/ro/crate/1.1" }
      },
      {
        "@id": "#workflow",
        "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
        "name": "InterLink VK uninstall workflow",
        "programmingLanguage": { "@id": "#scipion" }
      },
      {
        "@id": "#scipion",
        "@type": "ComputerLanguage",
        "name": "Scipion",
        "url": { "@id": "http://scipion.i2pc.es/" },
        "identifier": "http://scipion.i2pc.es/"
      },
      {
        "@id": "#destination",
        "@type": "Service",
        "serviceType": "Kubernetes",
        "action": "uninstall",
        "releaseName": "interlink-7d218f2f"
      }
    ]
 }
```

**Testing**

- manually validated InterLink VK deployment and manifest scheduling on the test cluster 
- manually validated Helm uninstall through RO-Crate-driven Kubernetes requests
- added Kubernetes RO-Crate examples for exercising the new flow
