### PR TITLE
Feature/binder extension

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -37,6 +37,10 @@ class FileProcessingError(VREError):
     pass
 
 
+class UnsupportedBinderSource(WorkflowConfigurationError):
+    pass
+
+
 class ExternalServiceError(VREError):
     """Raised when external service (Galaxy, Binder, etc.) fails"""
 

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -152,17 +152,11 @@ class VREBinder(VRE):
         if not remote_files:
             return
 
-        # Determine target directory from each remote file's id (e.g. "data/file.csv" → "data/")
         download_lines: list[str] = []
         for fref in remote_files:
             if not fref.url:
                 continue
-            target_dir = os.path.dirname(fref.id)
-            if target_dir and not target_dir.endswith("/"):
-                target_dir += "/"
-            download_lines.append(
-                f'./datahugger download "{fref.url}" --to "{target_dir}"'
-            )
+            download_lines.append(f'./datahugger download "{fref.url}" --to "data/"')
 
         if not download_lines:
             return

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 from .base_vre import VRE, vre_factory
 import os
-import urllib
+import urllib.parse
 from app.config import settings
 from vre_rocrate import BINDER_PROGRAMMING_LANGUAGE
 from app.constants import BINDER_DEFAULT_SERVICE
+from app.exceptions import UnsupportedBinderSource
 import git
 import logging
+import tempfile
+import shutil
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -14,28 +20,76 @@ class VREBinder(VRE):
     def get_default_service(self):
         return BINDER_DEFAULT_SERVICE
 
-    def post(self):
-        doi = self._get_zenodo_doi()
-        if doi:
-            return self._get_binder_zenodo_url(doi)
-        return self._get_binder_git_url()
+    def post(self) -> str:
+        if self.request_package.is_repository_only:
+            workflow_url = self.request_package.workflow.url
+            return self._build_binder_url(workflow_url)
+        return self._build_local_git_repo()
 
-    def _get_zenodo_doi(self) -> str | None:
-        """Extract Zenodo DOI from the workflow descriptor, if present."""
-        if self.request_package is None:
-            return None
-        return self.request_package.workflow.zenodo_doi
+    def _build_binder_url(self, url: str) -> str:
+        """Construct BinderHub URL from GitHub or Zenodo URL.
 
-    def _get_binder_zenodo_url(self, doi: str) -> str:
-        """Construct BinderHub URL for a Zenodo DOI."""
-        url = self.svc_url.rstrip("/")
-        return f"{url}/v2/zenodo/{doi}/"
+        Args:
+            url: Either a GitHub repo URL (https://github.com/org/repo[/tree/branch])
+                 or a Zenodo DOI URL (https://doi.org/10.xxxx/zenodo.NNNN)
 
-    def _get_binder_git_url(self) -> str:
-        """Prepare a local git repo from source files and return the Binder git URL."""
+        Returns:
+            BinderHub URL for the repository
+
+        Raises:
+            UnsupportedBinderSource: If URL is neither GitHub nor Zenodo
+        """
+        if "github.com" in url:
+            return self._build_github_binder_url(url)
+        if "zenodo" in url:
+            return self._build_zenodo_binder_url(url)
+        raise UnsupportedBinderSource(f"Unsupported repository source: {url}")
+
+    def _build_github_binder_url(self, url: str) -> str:
+        """Build BinderHub URL for GitHub repository.
+
+        Parses URLs like:
+        - https://github.com/org/repo → /v2/gh/org/repo/HEAD
+        - https://github.com/org/repo/tree/branch → /v2/gh/org/repo/branch
+        """
+        parsed = urllib.parse.urlparse(url)
+        path_parts = [p for p in parsed.path.split("/") if p]  # Remove empty strings
+
+        if len(path_parts) < 2:
+            raise UnsupportedBinderSource(f"Invalid GitHub URL: {url}")
+
+        org = path_parts[0]
+        repo = path_parts[1]
+
+        # Check for branch specification (/tree/branch)
+        ref = "HEAD"
+        if len(path_parts) >= 4 and path_parts[2] == "tree":
+            ref = path_parts[3]
+
+        return f"{self.svc_url}/v2/gh/{org}/{repo}/{ref}"
+
+    def _build_zenodo_binder_url(self, url: str) -> str:
+        """Build BinderHub URL for Zenodo DOI.
+
+        Parses URLs like:
+        - https://doi.org/10.5281/zenodo.12345 → /v2/zenodo/10.5281/zenodo.12345/
+        """
+        # Extract DOI from URL
+        doi = url
+        for prefix in ("https://doi.org/", "http://doi.org/"):
+            if doi.startswith(prefix):
+                doi = doi[len(prefix) :]
+                break
+
+        return f"{self.svc_url}/v2/zenodo/{doi}/"
+
+    def _build_local_git_repo(self) -> str:
+        """Prepare a local git repo from source files and optional remote clone, return Binder git URL."""
         repo = self._generate_repository_name(self._request_id)
         self._create(repo)
         self._write_source_files(repo)
+        self._write_start_script(repo)
+        self._clone_remote_files(self.request_package.workflow.url, repo)
         self._initialize_temporary_git_repo(repo)
         self._write_example_file(repo)
         url = self.svc_url.rstrip("/")
@@ -43,7 +97,7 @@ class VREBinder(VRE):
             f"https://{settings.host}{settings.git_url_prefix}/{self._request_id}"
         )
         logger.debug(local_git_url)
-        return f"{url}/git/{urllib.parse.quote_plus(local_git_url)}/HEAD"
+        return f"{url}/v2/git/{urllib.parse.quote_plus(local_git_url)}/HEAD"
 
     def _create(self, repo):
         os.mkdir(repo)
@@ -68,14 +122,118 @@ class VREBinder(VRE):
         gitrepos = settings.git_repos
         return f"{gitrepos}/{request_id}"
 
-    def _write_source_files(self, repo):
+    def _write_source_files(self, repo: str) -> None:
+        """Write local files from request package to repo directory.
+
+        Validates that filenames do not contain path traversal sequences (..).
+        """
         logger.debug(f"{__class__.__name__}: writing source files from request package")
         for fref in self.request_package.local_files:
             filename = fref.id
+            # Reject filenames with path traversal attempts
+            if ".." in filename:
+                logger.warning(
+                    f"Skipping file with invalid name (path traversal attempt): {filename}"
+                )
+                continue
             content = fref.properties.get("content")
             if content is not None:
-                with open(f"{repo}/{filename}", "wb") as f:
+                with open(os.path.join(repo, filename), "wb") as f:
                     f.write(content if isinstance(content, bytes) else content.encode())
+
+    def _write_start_script(self, repo: str) -> None:
+        """Write Binder start script that stages remote files via datahugger.
+
+        For each remote file in the request package, generates a datahugger
+        download command.  The script hands control back to Binder via ``exec "$@"``
+        so Jupyter starts normally after the files are staged.
+        """
+        remote_files = self.request_package.remote_files
+        if not remote_files:
+            return
+
+        # Determine target directory from each remote file's id (e.g. "data/file.csv" → "data/")
+        download_lines: list[str] = []
+        for fref in remote_files:
+            if not fref.url:
+                continue
+            target_dir = os.path.dirname(fref.id)
+            if target_dir and not target_dir.endswith("/"):
+                target_dir += "/"
+            download_lines.append(
+                f'./datahugger download "{fref.url}" --to "{target_dir}"'
+            )
+
+        if not download_lines:
+            return
+
+        script_path = os.path.join(repo, "start")
+        logger.debug(
+            f"{__class__.__name__}: writing start script with {len(download_lines)} datahugger commands"
+        )
+        with open(script_path, "w") as f:
+            f.write("#!/bin/bash\n")
+            f.write("set -e\n")
+            f.write("\n")
+            f.write("# Data staging via datahugger\n")
+            for line in download_lines:
+                f.write(f"{line}\n")
+            f.write("\n")
+            f.write("# Hand control back to Binder so Jupyter actually starts\n")
+            f.write('exec "$@"\n')
+
+        # Make the script executable
+        os.chmod(script_path, 0o755)
+
+    def _clone_remote_files(self, url: Optional[str], repo_path: str) -> None:
+        """Clone remote repository working tree into repo_path.
+
+        Only clones the working tree (not .git metadata) using shallow clone.
+        Does nothing if url is None.
+
+        Args:
+            url: Remote repository URL (GitHub only for now)
+            repo_path: Local directory to copy files into
+        """
+        if url is None:
+            return
+
+        # Only support GitHub URLs for cloning
+        if "github.com" not in url:
+            logger.warning(f"Skipping remote clone for non-GitHub URL: {url}")
+            return
+
+        try:
+            # Parse URL to get org/repo
+            parsed = urllib.parse.urlparse(url)
+            path_parts = [p for p in parsed.path.split("/") if p]
+
+            if len(path_parts) < 2:
+                logger.warning(f"Invalid GitHub URL for cloning: {url}")
+                return
+
+            org = path_parts[0]
+            repo = path_parts[1]
+            clone_url = f"https://github.com/{org}/{repo}.git"
+
+            # Create temp directory for clone
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                # Shallow clone to save time/space
+                git.Repo.clone_from(clone_url, tmp_dir, depth=1)
+
+                # Copy working tree files (excluding .git)
+                for item in os.listdir(tmp_dir):
+                    if item == ".git":
+                        continue
+                    src = os.path.join(tmp_dir, item)
+                    dst = os.path.join(repo_path, item)
+                    if os.path.isdir(src):
+                        shutil.copytree(src, dst, dirs_exist_ok=True)
+                    else:
+                        shutil.copy2(src, dst)
+
+        except Exception as e:
+            logger.warning(f"Failed to clone remote repository {url}: {e}")
 
 
 vre_factory.register(BINDER_PROGRAMMING_LANGUAGE, VREBinder)

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -91,6 +91,7 @@ class VREBinder(VRE):
         self._write_source_files(repo)
         self._clone_remote_files(self.request_package.workflow.url, repo)
         self._write_start_script(repo)
+        self._ensure_start_in_dockerfile(repo)
         self._initialize_temporary_git_repo(repo)
         self._write_example_file(repo)
         url = self.svc_url.rstrip("/")
@@ -206,6 +207,31 @@ class VREBinder(VRE):
 
         # Make the script executable
         os.chmod(script_path, 0o755)
+
+    def _ensure_start_in_dockerfile(self, repo: str) -> None:
+        """Patch Dockerfile to invoke the generated start script if both exist.
+
+        When a cloned repository contains a Dockerfile, Binder/repo2docker uses
+        it verbatim and ignores the repo-root ``start`` script.  Appending
+        ``COPY``, ``RUN chmod`` and ``ENTRYPOINT`` ensures the generated
+        ``start`` is executed inside the container.
+        """
+        dockerfile_path = os.path.join(repo, "Dockerfile")
+        start_path = os.path.join(repo, "start")
+
+        if not os.path.isfile(dockerfile_path):
+            return
+        if not os.path.isfile(start_path):
+            return
+
+        container_path = "/usr/local/bin/dispatcher-start"
+        with open(dockerfile_path, "a") as f:
+            f.write("\n# Added by dispatcher - start script integration\n")
+            f.write(f"COPY start {container_path}\n")
+            f.write(f"RUN chmod +x {container_path}\n")
+            f.write(f'ENTRYPOINT ["{container_path}"]\n')
+
+        logger.debug(f"{__class__.__name__}: patched Dockerfile to invoke start script")
 
     def _clone_remote_files(self, url: Optional[str], repo_path: str) -> None:
         """Clone remote repository working tree into repo_path.

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -224,11 +224,10 @@ class VREBinder(VRE):
         if not os.path.isfile(start_path):
             return
 
-        container_path = "/usr/local/bin/dispatcher-start"
+        container_path = "/usr/local/bin/start"
         with open(dockerfile_path, "a") as f:
             f.write("\n# Added by dispatcher - start script integration\n")
             f.write(f"COPY start {container_path}\n")
-            f.write(f"RUN chmod +x {container_path}\n")
             f.write(f'ENTRYPOINT ["{container_path}"]\n')
 
         logger.debug(f"{__class__.__name__}: patched Dockerfile to invoke start script")

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -200,10 +200,10 @@ class VREBinder(VRE):
                 f.write("# Source original start script from repository\n")
                 f.write("# (renamed from 'start' to avoid overwrite)\n")
                 f.write(f"source ./{os.path.basename(renamed_start)}\n")
-                f.write("\n")
-
-            f.write("# Hand control back to Binder so Jupyter actually starts\n")
-            f.write('exec "$@"\n')
+                f.write("# Original start hands control back to Binder\n")
+            else:
+                f.write("# Hand control back to Binder so Jupyter starts\n")
+                f.write('exec "$@"\n')
 
         # Make the script executable
         os.chmod(script_path, 0o755)

--- a/app/vres/binder.py
+++ b/app/vres/binder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .base_vre import VRE, vre_factory
 import os
 import urllib.parse
+import uuid
 from app.config import settings
 from vre_rocrate import BINDER_PROGRAMMING_LANGUAGE
 from app.constants import BINDER_DEFAULT_SERVICE
@@ -88,8 +89,8 @@ class VREBinder(VRE):
         repo = self._generate_repository_name(self._request_id)
         self._create(repo)
         self._write_source_files(repo)
-        self._write_start_script(repo)
         self._clone_remote_files(self.request_package.workflow.url, repo)
+        self._write_start_script(repo)
         self._initialize_temporary_git_repo(repo)
         self._write_example_file(repo)
         url = self.svc_url.rstrip("/")
@@ -142,37 +143,64 @@ class VREBinder(VRE):
                     f.write(content if isinstance(content, bytes) else content.encode())
 
     def _write_start_script(self, repo: str) -> None:
-        """Write Binder start script that stages remote files via datahugger.
+        """Write Binder start script that stages data and sources an existing start.
+
+        If a ``start`` script already exists in the repository (e.g. cloned from
+        a remote repo), it is renamed to a unique name and sourced by the newly
+        generated script so the original startup logic is preserved.
 
         For each remote file in the request package, generates a datahugger
         download command.  The script hands control back to Binder via ``exec "$@"``
         so Jupyter starts normally after the files are staged.
         """
+        existing_start = os.path.join(repo, "start")
+        renamed_start: str | None = None
+
+        # Preserve a pre-existing start script from a cloned repository
+        if os.path.isfile(existing_start):
+            unique_name = f"start.{uuid.uuid4().hex[:8]}"
+            renamed_start = os.path.join(repo, unique_name)
+            os.rename(existing_start, renamed_start)
+            os.chmod(renamed_start, 0o755)
+            logger.debug(
+                f"{__class__.__name__}: preserved existing start as {unique_name}"
+            )
+
         remote_files = self.request_package.remote_files
-        if not remote_files:
-            return
-
         download_lines: list[str] = []
-        for fref in remote_files:
-            if not fref.url:
-                continue
-            download_lines.append(f'./datahugger download "{fref.url}" --to "data/"')
+        if remote_files:
+            for fref in remote_files:
+                if not fref.url:
+                    continue
+                download_lines.append(
+                    f'./datahugger download "{fref.url}" --to "data/"'
+                )
 
-        if not download_lines:
+        if not download_lines and renamed_start is None:
             return
 
         script_path = os.path.join(repo, "start")
         logger.debug(
-            f"{__class__.__name__}: writing start script with {len(download_lines)} datahugger commands"
+            f"{__class__.__name__}: writing start script "
+            f"(downloads={len(download_lines)}, sourced={renamed_start is not None})"
         )
         with open(script_path, "w") as f:
             f.write("#!/bin/bash\n")
             f.write("set -e\n")
             f.write("\n")
-            f.write("# Data staging via datahugger\n")
-            for line in download_lines:
-                f.write(f"{line}\n")
-            f.write("\n")
+
+            if download_lines:
+                f.write("# Data staging via datahugger\n")
+                for line in download_lines:
+                    f.write(f"{line}\n")
+                f.write("\n")
+
+            if renamed_start is not None:
+                f.write("# Source original start script from repository\n")
+                f.write("# (renamed from 'start' to avoid overwrite)\n")
+                f.write(f"source ./{os.path.basename(renamed_start)}\n")
+                f.write("\n")
+
             f.write("# Hand control back to Binder so Jupyter actually starts\n")
             f.write('exec "$@"\n')
 

--- a/plans/test-binder-fix-testing-implementation.md
+++ b/plans/test-binder-fix-testing-implementation.md
@@ -1,0 +1,97 @@
+# Backlog: `test_binder.py` — Replace implementation-level tests with public-API tests
+
+Status: **planned** | File: [`test/unit/test_binder.py`](test/unit/test_binder.py)
+
+---
+
+## 1. Replace 5 `_build_binder_url` private-method tests with `test_post_*`
+
+**Problem:** Tests call `vre._build_binder_url(...)` — a private method — instead of the public `post()` contract. Two are redundant with existing `test_post_repository_only_*` tests.
+
+### 1.1. Add `test_post_repository_only_github_with_branch`
+
+- Fixture: `binder_vre_github_with_branch` (already exists in conftest)
+- Call: `post()`
+- Assert: returns `"https://mybinder.org/v2/gh/example/notebook-repo/main"`
+- Replaces: `test_build_binder_url_github_with_branch` (line 161)
+
+### 1.2. Add `test_post_repository_only_unsupported_source_raises`
+
+- Fixture: `binder_vre_gitlab_only` (already exists in conftest) — `is_repository_only=True`, URL is GitLab
+- Call: `post()`
+- Assert: raises `UnsupportedBinderSource`
+- Replaces: `test_build_binder_url_unsupported_raises_exception` (line 185)
+
+### 1.3. Remove 3 duplicate tests
+
+- `test_build_binder_url_github_simple` (line 153) — already covered by `test_post_repository_only_github`
+- `test_build_binder_url_zenodo` (line 169) — already covered by `test_post_repository_only_zenodo`
+- `test_build_binder_url_zenodo_http` (line 177) — already covered by `test_post_repository_only_zenodo` (which uses `http://`)
+
+### 1.4. Remove remaining 2 tests after replacement
+
+- `test_build_binder_url_github_with_branch` (line 161)
+- `test_build_binder_url_unsupported_raises_exception` (line 185)
+
+**Net:** 5 tests deleted, 2 added = 3 tests removed.
+
+---
+
+## 2. Replace 2 `_clone_remote_files` private-method tests
+
+### 2.1. `test_clone_remote_files_none_url_does_nothing` (line 205)
+
+- This path (`url=None`) is unreachable through `post()` because `_build_local_git_repo` calls `_clone_remote_files(self.request_package.workflow.url, repo)` — if `url=None` you'd get `is_repository_only=False` ∪ no clones. The test verifies a safe early-return in a defensive guard clause.
+- **Decision: keep as-is** — it's a valuable defensive guard test and cannot be expressed through the public API.
+
+### 2.2. `test_clone_remote_files_non_github_logs_warning` (line 217)
+
+- With a GitLab URL and `is_repository_only=False`, `post()` would hit `_build_local_git_repo` → `_clone_remote_files("https://gitlab.com/...", repo)` → warning. The test is reachable through `post()`, but asserting on log output (`caplog`) is fragile and still tests an internal implementation detail.
+- **Option A:** Convert to a `test_post_non_github_clone_logs_warning` — use `binder_vre_gitlab_only` with a local file to force `is_repository_only=False`, call `post()`, check caplog. Marginally better.
+- **Option B:** Keep as-is. The defensive guard against non-GitHub clones is tested.
+- **Recommendation:** Option B.
+
+---
+
+## 3. Consolidate 4 borderline side-effect tests
+
+These call `post()` but assert on filesystem/git side effects instead of return value or error behavior.
+
+### 3.1. `test_post_dir_created` (line 22) + `test_post_git_repo_initialized` (line 28)
+
+Both verify `post()` creates a git repo directory. A git repo directory existing is the same as a `.git` subdirectory existing. Merge into one:
+- `test_post_creates_git_repo` — call `post()` → assert `.git` dir exists
+
+### 3.2. `test_post_git_deamon_export_created` (line 34)
+
+Verifies `git-daemon-export-ok` file exists. This is an implementation detail of the git daemon setup. **Delete** — if git-daemon export breaks, the integration test will catch it.
+
+### 3.3. `test_post_git_commit` (line 42)
+
+Verifies commit message `"on the fly"`. This is a hardcoded string — testing an implementation constant. **Delete** — commit existence is verified by `test_post_git_repo_initialized` (repo exists means it was committed).
+
+**Net:** 4 tests → 1 consolidated test (3 tests removed).
+
+---
+
+## 4. `_write_start_script` tests (ours — keep as-is)
+
+Tests at lines 240–319 call `_write_start_script` directly — a private method. Testing through `post()` would require:
+1. Mock or real git clone of a repo with a `start` in it
+2. Assert on git repo content post-`post()`
+
+This is prohibitively complex for unit tests. These are defensible as practical exceptions. **No change.**
+
+---
+
+## Summary
+
+| Action | Tests |
+|--------|-------|
+| Delete (redundant/duplicate) | `test_build_binder_url_github_simple`, `test_build_binder_url_zenodo`, `test_build_binder_url_zenodo_http`, `test_post_git_deamon_export_created`, `test_post_git_commit` |
+| Delete (replaced by new) | `test_build_binder_url_github_with_branch`, `test_build_binder_url_unsupported_raises_exception` |
+| Merge | `test_post_dir_created` + `test_post_git_repo_initialized` → `test_post_creates_git_repo` |
+| Add new | `test_post_repository_only_github_with_branch`, `test_post_repository_only_unsupported_source_raises` |
+| Keep as-is | 5 `_classify_*` (already good), 3 `_write_start_script_*` (practical), 2 `_clone_remote_files_*` (defensive guards), 6 good `test_post_*` |
+
+**Net change:** 23 tests → 17 tests (-6). All remaining tests exercise the public `post()` contract or are documented defensive-guard exceptions.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,16 +205,96 @@ def binder_vre(dummy_binder_crate):
 
 @pytest.fixture
 def binder_vre_with_doi():
-    """Binder VRE with a Zenodo DOI as the workflow @id."""
+    """Binder VRE with a Zenodo DOI as the workflow @id (repository-only mode)."""
     workflow = WorkflowDescriptor(
         id="https://doi.org/10.5281/zenodo.12345678",
         type="SoftwareSourceCode",
+        url="https://doi.org/10.5281/zenodo.12345678",  # Added for repository-only mode
         programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
     )
     package = RequestPackage(
         vre_type=BINDER_PROGRAMMING_LANGUAGE,
         programming_language=BINDER_PROGRAMMING_LANGUAGE,
         workflow=workflow,
+        files=[],  # No local files for repository-only mode
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_github_only():
+    """Binder VRE with GitHub URL only (no local files) - repository-only mode."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/notebook-repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],  # No local files
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_github_with_branch():
+    """Binder VRE with GitHub URL including branch specification."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/notebook-repo/tree/main",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],  # No local files
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_zenodo_url():
+    """Binder VRE with Zenodo DOI URL (repository-only mode)."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://doi.org/10.5281/zenodo.12345678",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],  # No local files
         raw_crate={},
     )
     vre = VREBinder(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -282,6 +282,126 @@ def binder_vre_github_with_branch():
 
 
 @pytest.fixture
+def binder_vre_not_repo_only():
+    """Binder VRE with a local file so _build_local_git_repo path is taken."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    local_file = FileReference(
+        id="notebook.ipynb",
+        name="notebook.ipynb",
+        properties={"content": b"print('hello')"},
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[local_file],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_not_repo_only_with_remote():
+    """Binder VRE with a local file and a remote file (is_repository_only=False)."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    local_file = FileReference(
+        id="notebook.ipynb",
+        name="notebook.ipynb",
+        properties={"content": b"print('hello')"},
+    )
+    remote_file = FileReference(
+        id="https://example.org/data/file.csv",
+        name="file.csv",
+        url="https://example.org/data/file.csv",
+        properties={},
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[local_file, remote_file],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_no_url():
+    """Binder VRE with url=None (is_repository_only=False)."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url=None,
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
+def binder_vre_gitlab_only():
+    """Binder VRE with a GitLab URL (non-GitHub, non-Zenodo)."""
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://gitlab.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+    vre.svc_url = "https://mybinder.org"
+    return vre
+
+
+@pytest.fixture
 def binder_vre_zenodo_url():
     """Binder VRE with Zenodo DOI URL (repository-only mode)."""
     workflow = WorkflowDescriptor(

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -15,7 +15,7 @@ def test_post_happy_path(binder_vre):
 
     assert (
         final_url
-        == f'{binder_vre.svc_url.rstrip("/")}/git/{urllib.parse.quote_plus(local_git_url)}/HEAD'
+        == f'{binder_vre.svc_url.rstrip("/")}/v2/git/{urllib.parse.quote_plus(local_git_url)}/HEAD'
     )
 
 
@@ -67,22 +67,143 @@ def test_post_with_zenodo_doi(binder_vre_with_doi):
     assert result == "https://mybinder.org/v2/zenodo/10.5281/zenodo.12345678/"
 
 
-def test_get_zenodo_doi_returns_bare_doi(binder_vre_with_doi):
-    """Verify _get_zenodo_doi returns the bare DOI extracted from workflow @id."""
-    doi = binder_vre_with_doi._get_zenodo_doi()
-
-    assert doi == "10.5281/zenodo.12345678"
+# =============================================================================
+# Tests for repository-only mode and URL parsing
+# =============================================================================
 
 
-def test_get_zenodo_doi_none_when_no_zenodo_in_id_or_identifier(binder_vre):
-    """Verify _get_zenodo_doi returns None when neither id nor identifier contains zenodo."""
-    doi = binder_vre._get_zenodo_doi()
+def test_is_repository_only_true_when_url_and_no_local_files():
+    """Verify is_repository_only returns True when workflow has URL but no local files."""
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+    )
 
-    assert doi is None
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],  # No files at all
+        raw_crate={},
+    )
+
+    assert package.is_repository_only is True
 
 
-def test_get_zenodo_doi_from_id_when_identifier_is_none():
-    """Verify _get_zenodo_doi falls back to @id when identifier is None."""
+def test_is_repository_only_false_when_has_local_files():
+    """Verify is_repository_only returns False when local files are present."""
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+        FileReference,
+    )
+
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[
+            FileReference(id="notebook.ipynb", name="notebook.ipynb", properties={})
+        ],
+        raw_crate={},
+    )
+
+    assert package.is_repository_only is False
+
+
+def test_is_repository_only_false_when_no_url():
+    """Verify is_repository_only returns False when workflow has no URL."""
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+    )
+
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url=None,  # No URL
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],
+        raw_crate={},
+    )
+
+    assert package.is_repository_only is False
+
+
+def test_build_binder_url_github_simple(binder_vre_github_only):
+    """Test GitHub URL without branch specification defaults to HEAD."""
+    result = binder_vre_github_only._build_binder_url(
+        "https://github.com/example/notebook-repo"
+    )
+    assert result == "https://mybinder.org/v2/gh/example/notebook-repo/HEAD"
+
+
+def test_build_binder_url_github_with_branch(binder_vre_github_with_branch):
+    """Test GitHub URL with branch specification uses that branch."""
+    result = binder_vre_github_with_branch._build_binder_url(
+        "https://github.com/example/notebook-repo/tree/main"
+    )
+    assert result == "https://mybinder.org/v2/gh/example/notebook-repo/main"
+
+
+def test_build_binder_url_zenodo(binder_vre_zenodo_url):
+    """Test Zenodo DOI URL conversion."""
+    result = binder_vre_zenodo_url._build_binder_url(
+        "https://doi.org/10.5281/zenodo.12345678"
+    )
+    assert result == "https://mybinder.org/v2/zenodo/10.5281/zenodo.12345678/"
+
+
+def test_build_binder_url_zenodo_http(binder_vre_zenodo_url):
+    """Test Zenodo DOI URL with http protocol."""
+    result = binder_vre_zenodo_url._build_binder_url(
+        "http://doi.org/10.5281/zenodo.99999"
+    )
+    assert result == "https://mybinder.org/v2/zenodo/10.5281/zenodo.99999/"
+
+
+def test_build_binder_url_unsupported_raises_exception(binder_vre_github_only):
+    """Test that unsupported repository sources raise UnsupportedBinderSource."""
+    from app.exceptions import UnsupportedBinderSource
+
+    with pytest.raises(UnsupportedBinderSource):
+        binder_vre_github_only._build_binder_url("https://gitlab.com/example/repo")
+
+
+def test_post_repository_only_github(binder_vre_github_only):
+    """Test post() in repository-only mode with GitHub URL."""
+    result = binder_vre_github_only.post()
+    assert result == "https://mybinder.org/v2/gh/example/notebook-repo/HEAD"
+
+
+def test_post_repository_only_zenodo(binder_vre_zenodo_url):
+    """Test post() in repository-only mode with Zenodo URL."""
+    result = binder_vre_zenodo_url.post()
+    assert result == "https://mybinder.org/v2/zenodo/10.5281/zenodo.12345678/"
+
+
+def test_clone_remote_files_none_url_does_nothing(tmpdir):
+    """Test that _clone_remote_files does nothing when URL is None."""
     from vre_rocrate import (
         BINDER_PROGRAMMING_LANGUAGE,
         RequestPackage,
@@ -91,14 +212,16 @@ def test_get_zenodo_doi_from_id_when_identifier_is_none():
     from app.vres.binder import VREBinder
 
     workflow = WorkflowDescriptor(
-        id="https://doi.org/10.5281/zenodo.99999",
+        id="notebook.ipynb",
         type="SoftwareSourceCode",
+        url=None,
         programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
     )
     package = RequestPackage(
         vre_type=BINDER_PROGRAMMING_LANGUAGE,
         programming_language=BINDER_PROGRAMMING_LANGUAGE,
         workflow=workflow,
+        files=[],
         raw_crate={},
     )
     vre = VREBinder(
@@ -107,15 +230,19 @@ def test_get_zenodo_doi_from_id_when_identifier_is_none():
         update_state=None,
         request_package=package,
     )
-    vre.svc_url = "https://mybinder.org"
 
-    doi = vre._get_zenodo_doi()
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
 
-    assert doi == "10.5281/zenodo.99999"
+    # Should not raise any exception
+    vre._clone_remote_files(None, repo_path)
+
+    # Directory should be unchanged (empty except for what we created)
+    assert os.path.isdir(repo_path)
 
 
-def test_get_zenodo_doi_none_when_non_zenodo_identifier():
-    """Verify _get_zenodo_doi returns None for non-Zenodo identifiers."""
+def test_clone_remote_files_non_github_logs_warning(caplog, tmpdir):
+    """Test that non-GitHub URLs log a warning and do nothing."""
     from vre_rocrate import (
         BINDER_PROGRAMMING_LANGUAGE,
         RequestPackage,
@@ -124,14 +251,16 @@ def test_get_zenodo_doi_none_when_non_zenodo_identifier():
     from app.vres.binder import VREBinder
 
     workflow = WorkflowDescriptor(
-        id="https://doi.org/10.1234/figshare.5678",
+        id="notebook.ipynb",
         type="SoftwareSourceCode",
+        url="https://gitlab.com/example/repo",
         programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
     )
     package = RequestPackage(
         vre_type=BINDER_PROGRAMMING_LANGUAGE,
         programming_language=BINDER_PROGRAMMING_LANGUAGE,
         workflow=workflow,
+        files=[],
         raw_crate={},
     )
     vre = VREBinder(
@@ -140,48 +269,11 @@ def test_get_zenodo_doi_none_when_non_zenodo_identifier():
         update_state=None,
         request_package=package,
     )
-    vre.svc_url = "https://mybinder.org"
 
-    doi = vre._get_zenodo_doi()
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
 
-    assert doi is None
+    vre._clone_remote_files("https://gitlab.com/example/repo", repo_path)
 
-
-def test_get_binder_zenodo_url_construction(binder_vre_with_doi):
-    """Verify _get_binder_zenodo_url constructs the correct URL format."""
-    url = binder_vre_with_doi._get_binder_zenodo_url("10.5281/zenodo.12345678")
-
-    assert url == "https://mybinder.org/v2/zenodo/10.5281/zenodo.12345678/"
-
-
-def test_get_binder_zenodo_url_trailing_slash_handling():
-    """Verify _get_binder_zenodo_url handles svc_url with trailing slash."""
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-    )
-    from app.vres.binder import VREBinder
-
-    workflow = WorkflowDescriptor(
-        id="https://doi.org/10.5281/zenodo.99999",
-        type="SoftwareSourceCode",
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-    vre.svc_url = "https://mybinder.org/"
-
-    url = vre._get_binder_zenodo_url("10.5281/zenodo.99999")
-
-    assert url == "https://mybinder.org/v2/zenodo/10.5281/zenodo.99999/"
+    # Check that warning was logged
+    assert any("non-GitHub" in record.message for record in caplog.records)

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -202,78 +202,28 @@ def test_post_repository_only_zenodo(binder_vre_zenodo_url):
     assert result == "https://mybinder.org/v2/zenodo/10.5281/zenodo.12345678/"
 
 
-def test_clone_remote_files_none_url_does_nothing(tmpdir):
+def test_clone_remote_files_none_url_does_nothing(binder_vre_no_url, tmpdir):
     """Test that _clone_remote_files does nothing when URL is None."""
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-    )
-    from app.vres.binder import VREBinder
-
-    workflow = WorkflowDescriptor(
-        id="notebook.ipynb",
-        type="SoftwareSourceCode",
-        url=None,
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        files=[],
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-
     repo_path = str(tmpdir / "test_repo")
     os.makedirs(repo_path)
 
     # Should not raise any exception
-    vre._clone_remote_files(None, repo_path)
+    binder_vre_no_url._clone_remote_files(None, repo_path)
 
     # Directory should be unchanged (empty except for what we created)
     assert os.path.isdir(repo_path)
 
 
-def test_clone_remote_files_non_github_logs_warning(caplog, tmpdir):
+def test_clone_remote_files_non_github_logs_warning(
+    binder_vre_gitlab_only, caplog, tmpdir
+):
     """Test that non-GitHub URLs log a warning and do nothing."""
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-    )
-    from app.vres.binder import VREBinder
-
-    workflow = WorkflowDescriptor(
-        id="notebook.ipynb",
-        type="SoftwareSourceCode",
-        url="https://gitlab.com/example/repo",
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        files=[],
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-
     repo_path = str(tmpdir / "test_repo")
     os.makedirs(repo_path)
 
-    vre._clone_remote_files("https://gitlab.com/example/repo", repo_path)
+    binder_vre_gitlab_only._clone_remote_files(
+        "https://gitlab.com/example/repo", repo_path
+    )
 
     # Check that warning was logged
     assert any("non-GitHub" in record.message for record in caplog.records)
@@ -284,46 +234,21 @@ def test_clone_remote_files_non_github_logs_warning(caplog, tmpdir):
 # =============================================================================
 
 
-def test_write_start_script_preserves_existing(tmpdir):
-    """Existing 'start' from cloned repo is renamed and sourced by the new one."""
-    from app.vres.binder import VREBinder
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-    )
+EXISTING_START_CONTENT = "#!/bin/bash\necho 'original start'\n"
 
+
+def test_write_start_script_preserves_existing(binder_vre_not_repo_only, tmpdir):
+    """Existing 'start' from cloned repo is renamed and sourced by the new one."""
     repo_path = str(tmpdir / "test_repo")
     os.makedirs(repo_path)
 
     # Simulate a cloned repo that already has a start script
     existing_start = os.path.join(repo_path, "start")
     with open(existing_start, "w") as f:
-        f.write("#!/bin/bash\necho 'original start'\n")
+        f.write(EXISTING_START_CONTENT)
     os.chmod(existing_start, 0o755)
 
-    # Build a VRE with no remote files
-    workflow = WorkflowDescriptor(
-        id="notebook.ipynb",
-        type="SoftwareSourceCode",
-        url="https://github.com/example/repo",
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        files=[],
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-
-    vre._write_start_script(repo_path)
+    binder_vre_not_repo_only._write_start_script(repo_path)
 
     # New start should exist, be executable, and source the preserved one
     new_start = os.path.join(repo_path, "start")
@@ -335,98 +260,40 @@ def test_write_start_script_preserves_existing(tmpdir):
     assert "source ./start." in content
     assert 'exec "$@"' in content
 
-    # The preserved script should still be on disk and executable
+    # The preserved script should still be on disk, executable, with original content
     preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]
     assert len(preserved_files) == 1
     preserved_path = os.path.join(repo_path, preserved_files[0])
     assert os.access(preserved_path, os.X_OK)
+    with open(preserved_path) as f:
+        assert f.read() == EXISTING_START_CONTENT
 
 
-def test_write_start_script_no_existing_no_remote(tmpdir):
+def test_write_start_script_no_existing_no_remote(binder_vre_not_repo_only, tmpdir):
     """No existing start and no remote files: no start script is created."""
-    from app.vres.binder import VREBinder
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-    )
-
     repo_path = str(tmpdir / "test_repo")
     os.makedirs(repo_path)
 
-    workflow = WorkflowDescriptor(
-        id="notebook.ipynb",
-        type="SoftwareSourceCode",
-        url="https://github.com/example/repo",
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        files=[],
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-
-    vre._write_start_script(repo_path)
+    binder_vre_not_repo_only._write_start_script(repo_path)
 
     # No start script should have been created
     assert not os.path.isfile(os.path.join(repo_path, "start"))
 
 
-def test_write_start_script_existing_plus_remote_files(tmpdir):
+def test_write_start_script_existing_plus_remote_files(
+    binder_vre_not_repo_only_with_remote, tmpdir
+):
     """Existing start + remote files: datahugger lines come first, then source."""
-    from app.vres.binder import VREBinder
-    from vre_rocrate import (
-        BINDER_PROGRAMMING_LANGUAGE,
-        RequestPackage,
-        WorkflowDescriptor,
-        FileReference,
-    )
-
     repo_path = str(tmpdir / "test_repo")
     os.makedirs(repo_path)
 
     # Simulate a cloned repo that already has a start script
     existing_start = os.path.join(repo_path, "start")
     with open(existing_start, "w") as f:
-        f.write("#!/bin/bash\necho 'original start'\n")
+        f.write(EXISTING_START_CONTENT)
     os.chmod(existing_start, 0o755)
 
-    # Build a VRE with remote files
-    workflow = WorkflowDescriptor(
-        id="notebook.ipynb",
-        type="SoftwareSourceCode",
-        url="https://github.com/example/repo",
-        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
-    )
-    remote_file = FileReference(
-        id="https://example.org/data/file.csv",
-        name="file.csv",
-        url="https://example.org/data/file.csv",
-        properties={},
-    )
-    package = RequestPackage(
-        vre_type=BINDER_PROGRAMMING_LANGUAGE,
-        programming_language=BINDER_PROGRAMMING_LANGUAGE,
-        workflow=workflow,
-        files=[remote_file],
-        raw_crate={},
-    )
-    vre = VREBinder(
-        token="test-token",
-        request_id=0,
-        update_state=None,
-        request_package=package,
-    )
-
-    vre._write_start_script(repo_path)
+    binder_vre_not_repo_only_with_remote._write_start_script(repo_path)
 
     # New start should exist and contain both datahugger and source lines
     new_start = os.path.join(repo_path, "start")
@@ -444,6 +311,9 @@ def test_write_start_script_existing_plus_remote_files(tmpdir):
     idx_exec = content.index('exec "$@"')
     assert idx_dh < idx_source < idx_exec
 
-    # Preserved script should exist
+    # Preserved script should exist with original content
     preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]
     assert len(preserved_files) == 1
+    preserved_path = os.path.join(repo_path, preserved_files[0])
+    with open(preserved_path) as f:
+        assert f.read() == EXISTING_START_CONTENT

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -277,3 +277,173 @@ def test_clone_remote_files_non_github_logs_warning(caplog, tmpdir):
 
     # Check that warning was logged
     assert any("non-GitHub" in record.message for record in caplog.records)
+
+
+# =============================================================================
+# Tests for _write_start_script with cloned start script preservation
+# =============================================================================
+
+
+def test_write_start_script_preserves_existing(tmpdir):
+    """Existing 'start' from cloned repo is renamed and sourced by the new one."""
+    from app.vres.binder import VREBinder
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+    )
+
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    # Simulate a cloned repo that already has a start script
+    existing_start = os.path.join(repo_path, "start")
+    with open(existing_start, "w") as f:
+        f.write("#!/bin/bash\necho 'original start'\n")
+    os.chmod(existing_start, 0o755)
+
+    # Build a VRE with no remote files
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+
+    vre._write_start_script(repo_path)
+
+    # New start should exist, be executable, and source the preserved one
+    new_start = os.path.join(repo_path, "start")
+    assert os.path.isfile(new_start)
+    assert os.access(new_start, os.X_OK)
+
+    with open(new_start) as f:
+        content = f.read()
+    assert "source ./start." in content
+    assert 'exec "$@"' in content
+
+    # The preserved script should still be on disk and executable
+    preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]
+    assert len(preserved_files) == 1
+    preserved_path = os.path.join(repo_path, preserved_files[0])
+    assert os.access(preserved_path, os.X_OK)
+
+
+def test_write_start_script_no_existing_no_remote(tmpdir):
+    """No existing start and no remote files: no start script is created."""
+    from app.vres.binder import VREBinder
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+    )
+
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+
+    vre._write_start_script(repo_path)
+
+    # No start script should have been created
+    assert not os.path.isfile(os.path.join(repo_path, "start"))
+
+
+def test_write_start_script_existing_plus_remote_files(tmpdir):
+    """Existing start + remote files: datahugger lines come first, then source."""
+    from app.vres.binder import VREBinder
+    from vre_rocrate import (
+        BINDER_PROGRAMMING_LANGUAGE,
+        RequestPackage,
+        WorkflowDescriptor,
+        FileReference,
+    )
+
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    # Simulate a cloned repo that already has a start script
+    existing_start = os.path.join(repo_path, "start")
+    with open(existing_start, "w") as f:
+        f.write("#!/bin/bash\necho 'original start'\n")
+    os.chmod(existing_start, 0o755)
+
+    # Build a VRE with remote files
+    workflow = WorkflowDescriptor(
+        id="notebook.ipynb",
+        type="SoftwareSourceCode",
+        url="https://github.com/example/repo",
+        programming_language_id=BINDER_PROGRAMMING_LANGUAGE,
+    )
+    remote_file = FileReference(
+        id="https://example.org/data/file.csv",
+        name="file.csv",
+        url="https://example.org/data/file.csv",
+        properties={},
+    )
+    package = RequestPackage(
+        vre_type=BINDER_PROGRAMMING_LANGUAGE,
+        programming_language=BINDER_PROGRAMMING_LANGUAGE,
+        workflow=workflow,
+        files=[remote_file],
+        raw_crate={},
+    )
+    vre = VREBinder(
+        token="test-token",
+        request_id=0,
+        update_state=None,
+        request_package=package,
+    )
+
+    vre._write_start_script(repo_path)
+
+    # New start should exist and contain both datahugger and source lines
+    new_start = os.path.join(repo_path, "start")
+    assert os.path.isfile(new_start)
+    with open(new_start) as f:
+        content = f.read()
+
+    # datahugger download should appear before the source line
+    assert "datahugger download" in content
+    assert "source ./start." in content
+    assert 'exec "$@"' in content
+
+    idx_dh = content.index("datahugger")
+    idx_source = content.index("source ./start.")
+    idx_exec = content.index('exec "$@"')
+    assert idx_dh < idx_source < idx_exec
+
+    # Preserved script should exist
+    preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]
+    assert len(preserved_files) == 1

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -317,3 +317,67 @@ def test_write_start_script_existing_plus_remote_files(
     preserved_path = os.path.join(repo_path, preserved_files[0])
     with open(preserved_path) as f:
         assert f.read() == EXISTING_START_CONTENT
+
+
+# =============================================================================
+# Tests for _ensure_start_in_dockerfile
+# =============================================================================
+
+
+def test_ensure_dockerfile_absent_does_nothing(binder_vre_not_repo_only, tmpdir):
+    """Dockerfile is not created when it doesn't already exist."""
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    # Create a start script so the guard passes
+    start_path = os.path.join(repo_path, "start")
+    with open(start_path, "w") as f:
+        f.write("#!/bin/bash\necho ok\n")
+    os.chmod(start_path, 0o755)
+
+    binder_vre_not_repo_only._ensure_start_in_dockerfile(repo_path)
+
+    assert not os.path.isfile(os.path.join(repo_path, "Dockerfile"))
+
+
+def test_ensure_dockerfile_present_no_start_does_nothing(
+    binder_vre_not_repo_only, tmpdir
+):
+    """Dockerfile is left unchanged when no start script exists."""
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    dockerfile_path = os.path.join(repo_path, "Dockerfile")
+    original = "FROM ubuntu:latest\n"
+    with open(dockerfile_path, "w") as f:
+        f.write(original)
+
+    binder_vre_not_repo_only._ensure_start_in_dockerfile(repo_path)
+
+    with open(dockerfile_path) as f:
+        assert f.read() == original
+
+
+def test_ensure_dockerfile_present_with_start_patches(binder_vre_not_repo_only, tmpdir):
+    """Dockerfile is patched to invoke start when both exist."""
+    repo_path = str(tmpdir / "test_repo")
+    os.makedirs(repo_path)
+
+    # Create both Dockerfile and start
+    dockerfile_path = os.path.join(repo_path, "Dockerfile")
+    with open(dockerfile_path, "w") as f:
+        f.write("FROM ubuntu:latest\n")
+
+    start_path = os.path.join(repo_path, "start")
+    with open(start_path, "w") as f:
+        f.write("#!/bin/bash\necho ok\n")
+    os.chmod(start_path, 0o755)
+
+    binder_vre_not_repo_only._ensure_start_in_dockerfile(repo_path)
+
+    with open(dockerfile_path) as f:
+        content = f.read()
+
+    assert 'ENTRYPOINT ["/usr/local/bin/dispatcher-start"]' in content
+    assert "COPY start /usr/local/bin/dispatcher-start" in content
+    assert "RUN chmod +x /usr/local/bin/dispatcher-start" in content

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -378,6 +378,5 @@ def test_ensure_dockerfile_present_with_start_patches(binder_vre_not_repo_only, 
     with open(dockerfile_path) as f:
         content = f.read()
 
-    assert 'ENTRYPOINT ["/usr/local/bin/dispatcher-start"]' in content
-    assert "COPY start /usr/local/bin/dispatcher-start" in content
-    assert "RUN chmod +x /usr/local/bin/dispatcher-start" in content
+    assert 'ENTRYPOINT ["/usr/local/bin/start"]' in content
+    assert "COPY start /usr/local/bin/start" in content

--- a/test/unit/test_binder.py
+++ b/test/unit/test_binder.py
@@ -258,7 +258,8 @@ def test_write_start_script_preserves_existing(binder_vre_not_repo_only, tmpdir)
     with open(new_start) as f:
         content = f.read()
     assert "source ./start." in content
-    assert 'exec "$@"' in content
+    # Original start already execs "$@", so our wrapper must not
+    assert 'exec "$@"' not in content
 
     # The preserved script should still be on disk, executable, with original content
     preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]
@@ -304,12 +305,12 @@ def test_write_start_script_existing_plus_remote_files(
     # datahugger download should appear before the source line
     assert "datahugger download" in content
     assert "source ./start." in content
-    assert 'exec "$@"' in content
+    # Original start already execs "$@", so our wrapper must not
+    assert 'exec "$@"' not in content
 
     idx_dh = content.index("datahugger")
     idx_source = content.index("source ./start.")
-    idx_exec = content.index('exec "$@"')
-    assert idx_dh < idx_source < idx_exec
+    assert idx_dh < idx_source
 
     # Preserved script should exist with original content
     preserved_files = [f for f in os.listdir(repo_path) if f.startswith("start.")]


### PR DESCRIPTION
There is a caveat here -- the cloning setup is highly dependent on the structure of the repository. If it contains Dockerfile, the `start` script that is being generated needs to be executed inside the Dockerfile like this  `ENTRYPOINT ["/usr/local/bin/start"]`. If Dockerfile is not present, this should work fine.