### PR TITLE
Feature/deploy from local upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-FROM python:3.13  
+FROM python:3.13
 
 RUN groupadd -r celery && useradd -r -g celery celery
 WORKDIR /usr/src
- 
-# Set environment variables 
+
+# Set environment variables
 # Prevents Python from writing pyc files to disk
 ENV PYTHONDONTWRITEBYTECODE=1
 #Prevents Python from buffering stdout and stderr
-ENV PYTHONUNBUFFERED=1 
- 
+ENV PYTHONUNBUFFERED=1
+
 # Upgrade pip
-RUN pip install --upgrade pip 
- 
-# Copy the Django project  and install dependencies
+RUN pip install --upgrade pip
+
+# Copy requirements and dispatcher code (vre-rocrate is optional for local builds)
 COPY requirements.txt /usr/src
-
-# run this command to install all dependencies 
-RUN pip install --no-cache-dir -r requirements.txt
-
 COPY . /usr/src
+
+# Install dependencies.
+# If vre-rocrate/ directory was copied into the build context (e.g. by source_local role),
+# install it from there. Otherwise install from the github URL in requirements.txt.
+RUN if [ -d "/usr/src/vre-rocrate" ]; then \
+    pip install --no-cache-dir -e /usr/src/vre-rocrate && \
+    grep -v "vre-rocrate" requirements.txt > /tmp/requirements-no-vre.txt && \
+    pip install --no-cache-dir -r /tmp/requirements-no-vre.txt; \
+    else \
+    pip install --no-cache-dir -r requirements.txt; \
+    fi

--- a/ansible/group_vars/dispatchers/vars.yml
+++ b/ansible/group_vars/dispatchers/vars.yml
@@ -65,6 +65,6 @@ im:
     #VO: vo.eosc-data-commons.eu
 
 logging:
-  level: INFO
+  level: "{{ 'INFO' if api.environment == 'prod' else 'DEBUG' }}"
   format: text
     

--- a/ansible/roles/source_local/tasks/main.yml
+++ b/ansible/roles/source_local/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
-- name: Copy local version of repo
+- name: Copy local version of dispatcher repo
   synchronize:
     src: "{{ playbook_dir }}/../"
     dest: "{{ dispatcher.dir }}"
+
+- name: Copy local version of vre-rocrate if it exists locally
+  synchronize:
+    src: "{{ playbook_dir }}/../../vre-rocrate/"
+    dest: "{{ dispatcher.dir }}/vre-rocrate/"


### PR DESCRIPTION
This aims to always use local version of vre-rocrate to speed up the deployment and enable fast iterations.